### PR TITLE
Add multi-user agent registry and installer

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,334 @@
+"""SQLite-backed persistence for users and agents."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from .models import Agent, User
+
+
+def _ensure_directory(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def resolve_database_path(env_value: Optional[str]) -> Path:
+    """Resolve the on-disk path for the application database."""
+
+    if env_value:
+        return Path(env_value).expanduser().resolve(strict=False)
+    base_dir = Path(__file__).resolve().parent.parent / "data"
+    return (base_dir / "management.sqlite3").resolve(strict=False)
+
+
+def _current_timestamp() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _serialize_datetime(value: datetime) -> str:
+    return value.isoformat()
+
+
+def _parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _generate_api_key() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _hash_api_key(api_key: str, salt: bytes) -> bytes:
+    return hashlib.pbkdf2_hmac("sha256", api_key.encode("utf-8"), salt, 600_000)
+
+
+class Database:
+    """Simple wrapper around SQLite for persisting users and agents."""
+
+    def __init__(self, path: Path) -> None:
+        _ensure_directory(path)
+        self._path = path
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def initialize(self) -> None:
+        """Create the required tables if they do not already exist."""
+
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    email TEXT UNIQUE,
+                    api_key_prefix TEXT NOT NULL,
+                    api_key_hash TEXT NOT NULL,
+                    api_key_salt TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS agents (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    name TEXT NOT NULL,
+                    hostname TEXT NOT NULL,
+                    port INTEGER NOT NULL DEFAULT 22,
+                    username TEXT NOT NULL,
+                    private_key TEXT NOT NULL,
+                    private_key_passphrase TEXT,
+                    allow_unknown_hosts INTEGER NOT NULL DEFAULT 0,
+                    known_hosts_path TEXT,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_agents_user_id ON agents(user_id);
+                CREATE INDEX IF NOT EXISTS idx_users_api_key_prefix ON users(api_key_prefix);
+                """
+            )
+
+    # ------------------------------------------------------------------
+    # User management
+    # ------------------------------------------------------------------
+    def create_user(self, name: str, email: Optional[str] = None) -> Tuple[User, str]:
+        """Create a new user and return it along with the generated API key."""
+
+        created_at = _current_timestamp()
+        api_key = _generate_api_key()
+        salt = secrets.token_bytes(16)
+        hash_bytes = _hash_api_key(api_key, salt)
+        prefix = api_key[:8]
+
+        with self._connect() as conn:
+            try:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO users (name, email, api_key_prefix, api_key_hash, api_key_salt, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        name,
+                        email,
+                        prefix,
+                        base64.b64encode(hash_bytes).decode("ascii"),
+                        base64.b64encode(salt).decode("ascii"),
+                        _serialize_datetime(created_at),
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise ValueError("A user with that email already exists") from exc
+
+            user_id = cursor.lastrowid
+
+        user = User(id=user_id, name=name, email=email, api_key_prefix=prefix, created_at=created_at)
+        return user, api_key
+
+    def get_user(self, user_id: int) -> Optional[User]:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+        if row is None:
+            return None
+        return self._row_to_user(row)
+
+    def get_user_by_api_key(self, api_key: str) -> Optional[User]:
+        prefix = api_key[:8]
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM users WHERE api_key_prefix = ?",
+                (prefix,),
+            ).fetchall()
+
+        for row in rows:
+            salt = base64.b64decode(row["api_key_salt"])
+            expected_hash = base64.b64decode(row["api_key_hash"])
+            calculated = _hash_api_key(api_key, salt)
+            if hmac.compare_digest(expected_hash, calculated):
+                return self._row_to_user(row)
+        return None
+
+    def rotate_api_key(self, user_id: int) -> Tuple[User, str]:
+        user = self.get_user(user_id)
+        if user is None:
+            raise ValueError("User not found")
+
+        api_key = _generate_api_key()
+        salt = secrets.token_bytes(16)
+        hash_bytes = _hash_api_key(api_key, salt)
+        prefix = api_key[:8]
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE users
+                   SET api_key_prefix = ?, api_key_hash = ?, api_key_salt = ?
+                 WHERE id = ?
+                """,
+                (
+                    prefix,
+                    base64.b64encode(hash_bytes).decode("ascii"),
+                    base64.b64encode(salt).decode("ascii"),
+                    user_id,
+                ),
+            )
+
+        refreshed = self.get_user(user_id)
+        if refreshed is None:
+            raise ValueError("User not found")
+        return refreshed, api_key
+
+    # ------------------------------------------------------------------
+    # Agent management
+    # ------------------------------------------------------------------
+    def create_agent(
+        self,
+        user_id: int,
+        *,
+        name: str,
+        hostname: str,
+        port: int,
+        username: str,
+        private_key: str,
+        private_key_passphrase: Optional[str],
+        allow_unknown_hosts: bool,
+        known_hosts_path: Optional[str],
+    ) -> Agent:
+        created_at = _current_timestamp()
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO agents (
+                    user_id, name, hostname, port, username, private_key, private_key_passphrase,
+                    allow_unknown_hosts, known_hosts_path, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    user_id,
+                    name,
+                    hostname,
+                    port,
+                    username,
+                    private_key.strip(),
+                    private_key_passphrase,
+                    int(bool(allow_unknown_hosts)),
+                    known_hosts_path,
+                    _serialize_datetime(created_at),
+                ),
+            )
+            agent_id = cursor.lastrowid
+
+        agent = self.get_agent_for_user(user_id, agent_id)
+        if agent is None:
+            raise RuntimeError("Failed to load agent after creation")
+        return agent
+
+    def list_agents_for_user(self, user_id: int) -> List[Agent]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM agents WHERE user_id = ? ORDER BY name",
+                (user_id,),
+            ).fetchall()
+        return [self._row_to_agent(row) for row in rows]
+
+    def get_agent_for_user(self, user_id: int, agent_id: int) -> Optional[Agent]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM agents WHERE user_id = ? AND id = ?",
+                (user_id, agent_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_agent(row)
+
+    def delete_agent(self, user_id: int, agent_id: int) -> bool:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM agents WHERE user_id = ? AND id = ?",
+                (user_id, agent_id),
+            )
+            return cursor.rowcount > 0
+
+    def update_agent(
+        self,
+        user_id: int,
+        agent_id: int,
+        **fields: object,
+    ) -> Optional[Agent]:
+        if not fields:
+            return self.get_agent_for_user(user_id, agent_id)
+
+        allowed = {
+            "name": "name",
+            "hostname": "hostname",
+            "port": "port",
+            "username": "username",
+            "private_key": "private_key",
+            "private_key_passphrase": "private_key_passphrase",
+            "allow_unknown_hosts": "allow_unknown_hosts",
+            "known_hosts_path": "known_hosts_path",
+        }
+
+        updates: List[str] = []
+        values: List[object] = []
+        nullable_columns = {"private_key_passphrase", "known_hosts_path"}
+        for key, column in allowed.items():
+            if key not in fields:
+                continue
+            value = fields[key]
+            if value is None and column not in nullable_columns:
+                continue
+            if column == "private_key":
+                value = str(value).strip()
+            if column == "allow_unknown_hosts":
+                value = int(bool(value))
+            updates.append(f"{column} = ?")
+            values.append(value)
+
+        if not updates:
+            return self.get_agent_for_user(user_id, agent_id)
+
+        values.extend([user_id, agent_id])
+        query = f"UPDATE agents SET {', '.join(updates)} WHERE user_id = ? AND id = ?"
+
+        with self._connect() as conn:
+            cursor = conn.execute(query, values)
+            if cursor.rowcount == 0:
+                return None
+
+        return self.get_agent_for_user(user_id, agent_id)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _row_to_user(self, row: sqlite3.Row) -> User:
+        return User(
+            id=int(row["id"]),
+            name=str(row["name"]),
+            email=row["email"],
+            api_key_prefix=str(row["api_key_prefix"]),
+            created_at=_parse_datetime(str(row["created_at"])),
+        )
+
+    def _row_to_agent(self, row: sqlite3.Row) -> Agent:
+        return Agent(
+            id=int(row["id"]),
+            user_id=int(row["user_id"]),
+            name=str(row["name"]),
+            hostname=str(row["hostname"]),
+            port=int(row["port"]),
+            username=str(row["username"]),
+            private_key=str(row["private_key"]),
+            private_key_passphrase=row["private_key_passphrase"],
+            allow_unknown_hosts=bool(row["allow_unknown_hosts"]),
+            known_hosts_path=row["known_hosts_path"],
+            created_at=_parse_datetime(str(row["created_at"])),
+        )
+
+
+__all__ = ["Database", "resolve_database_path"]

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,37 @@
+"""Domain models for the management service."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class User:
+    """Represents an authenticated user of the management service."""
+
+    id: int
+    name: str
+    email: Optional[str]
+    api_key_prefix: str
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class Agent:
+    """Represents a remote virtualization agent owned by a user."""
+
+    id: int
+    user_id: int
+    name: str
+    hostname: str
+    port: int
+    username: str
+    private_key: str
+    private_key_passphrase: Optional[str]
+    allow_unknown_hosts: bool
+    known_hosts_path: Optional[str]
+    created_at: datetime
+
+
+__all__ = ["Agent", "User"]

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass
+from io import StringIO
 from pathlib import Path
-from typing import Generator, Sequence
+from typing import Generator, Optional, Sequence
 
 import shlex
 
 import paramiko
-
-from .config import HostConfig
 
 
 class SSHError(RuntimeError):
@@ -27,9 +26,45 @@ class CommandResult:
     stderr: str
 
 
-def _load_private_key(path: Path, passphrase: str | None) -> paramiko.PKey:
+@dataclass
+class SSHTarget:
+    """Connection parameters for a remote host."""
+
+    hostname: str
+    port: int
+    username: str
+    private_key: str
+    passphrase: Optional[str] = None
+    allow_unknown_hosts: bool = False
+    known_hosts_path: Optional[Path] = None
+
+
+def _load_private_key(private_key: str, passphrase: str | None) -> paramiko.PKey:
+    key_classes = (
+        paramiko.Ed25519Key,
+        paramiko.ECDSAKey,
+        paramiko.RSAKey,
+        paramiko.DSSKey,
+    )
+    cleaned = private_key.strip()
+
+    if "-----BEGIN" in cleaned:
+        last_error: Exception | None = None
+        for key_cls in key_classes:
+            stream = StringIO(cleaned)
+            try:
+                return key_cls.from_private_key(stream, password=passphrase)
+            except paramiko.PasswordRequiredException as exc:
+                raise SSHError("The private key is encrypted and requires a passphrase") from exc
+            except paramiko.SSHException as exc:
+                last_error = exc
+        if last_error is None:
+            raise SSHError("Unable to load private key - unsupported format or invalid passphrase")
+        raise SSHError("Unable to load private key - unsupported format or invalid passphrase") from last_error
+
+    path = Path(cleaned)
     exceptions: list[Exception] = []
-    for key_cls in (paramiko.Ed25519Key, paramiko.ECDSAKey, paramiko.RSAKey, paramiko.DSSKey):
+    for key_cls in key_classes:
         try:
             return key_cls.from_private_key_file(str(path), password=passphrase)
         except FileNotFoundError as exc:
@@ -44,28 +79,28 @@ def _load_private_key(path: Path, passphrase: str | None) -> paramiko.PKey:
 class SSHClientFactory:
     """Factory that builds SSH clients using host configuration."""
 
-    def __init__(self, host_config: HostConfig) -> None:
-        self._config = host_config
+    def __init__(self, target: SSHTarget) -> None:
+        self._target = target
 
     @contextmanager
     def connect(self) -> Generator[paramiko.SSHClient, None, None]:
         client = paramiko.SSHClient()
-        if self._config.known_hosts_file:
-            client.load_host_keys(str(self._config.known_hosts_file))
+        if self._target.known_hosts_path:
+            client.load_host_keys(str(self._target.known_hosts_path))
         else:
             client.load_system_host_keys()
 
-        if self._config.allow_unknown_hosts:
+        if self._target.allow_unknown_hosts:
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         else:
             client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
-        pkey = _load_private_key(self._config.private_key_path, self._config.passphrase)
+        pkey = _load_private_key(self._target.private_key, self._target.passphrase)
         try:
             client.connect(
-                hostname=self._config.hostname,
-                port=self._config.port,
-                username=self._config.username,
+                hostname=self._target.hostname,
+                port=self._target.port,
+                username=self._target.username,
                 pkey=pkey,
                 timeout=20,
                 look_for_keys=False,
@@ -101,4 +136,4 @@ class SSHCommandRunner:
         return CommandResult(command=args, exit_status=exit_status, stdout=stdout_text, stderr=stderr_text)
 
 
-__all__ = ["SSHError", "CommandResult", "SSHClientFactory", "SSHCommandRunner"]
+__all__ = ["SSHError", "CommandResult", "SSHTarget", "SSHClientFactory", "SSHCommandRunner"]

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,4 @@
+# Ignore generated SQLite databases
+*.sqlite3
+*.sqlite
+*.db

--- a/main.py
+++ b/main.py
@@ -1,8 +1,21 @@
 """Entry point for running the management API."""
 from __future__ import annotations
 
+import os
+
 import uvicorn
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 if __name__ == "__main__":
-    uvicorn.run("app.api:app", host="0.0.0.0", port=80, reload=False, workers=1)
+    host = os.getenv("MANAGEMENT_HOST", "0.0.0.0")
+    port = int(os.getenv("MANAGEMENT_PORT", "8000"))
+    workers = int(os.getenv("MANAGEMENT_WORKERS", "1"))
+    reload = _env_flag("MANAGEMENT_RELOAD", False)
+    uvicorn.run("app.api:app", host=host, port=port, reload=reload, workers=workers)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "This installer must be run as root (try again with sudo)." >&2
+    exit 1
+fi
+
+APP_USER="${APP_USER:-playrmanager}"
+APP_GROUP="$APP_USER"
+APP_DIR="${APP_DIR:-/opt/manage.playrservers}"
+APP_REPO="${APP_REPO:-}"
+APP_BRANCH="${APP_BRANCH:-main}"
+APP_PORT="${APP_PORT:-8000}"
+APP_HOST="${APP_HOST:-127.0.0.1}"
+SERVICE_NAME="${SERVICE_NAME:-manage-playrservers}"
+APP_DOMAIN="${APP_DOMAIN:-manage.playrservers.com}"
+INSTALL_NGINX="${INSTALL_NGINX:-1}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+ENV_FILE="${APP_ENV_FILE:-/etc/manage-playrservers.env}"
+
+APT_PACKAGES=(python3 python3-venv python3-pip git rsync)
+if [[ "$INSTALL_NGINX" == "1" ]]; then
+    APT_PACKAGES+=(nginx)
+fi
+
+apt-get update
+apt-get install -y "${APT_PACKAGES[@]}"
+
+if ! id "$APP_USER" &>/dev/null; then
+    useradd --system --create-home --home-dir "/var/lib/${SERVICE_NAME}" --shell /usr/sbin/nologin "$APP_USER"
+fi
+
+mkdir -p "$APP_DIR"
+
+if [[ -n "$APP_REPO" ]]; then
+    if [[ ! -d "$APP_DIR/.git" ]]; then
+        git clone --branch "$APP_BRANCH" "$APP_REPO" "$APP_DIR"
+    else
+        git -C "$APP_DIR" fetch --all --tags
+        git -C "$APP_DIR" checkout "$APP_BRANCH"
+        git -C "$APP_DIR" pull --ff-only
+    fi
+else
+    PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+    rsync -a --delete "$PROJECT_ROOT/" "$APP_DIR/" \
+        --exclude '.git' \
+        --exclude '.venv' \
+        --exclude '__pycache__' \
+        --exclude '*.pyc'
+fi
+
+chown -R "$APP_USER:$APP_GROUP" "$APP_DIR"
+
+sudo -u "$APP_USER" "$PYTHON_BIN" -m venv "$APP_DIR/.venv"
+sudo -u "$APP_USER" bash -c "set -euo pipefail; source '$APP_DIR/.venv/bin/activate'; pip install --upgrade pip; pip install -r '$APP_DIR/requirements.txt'"
+
+install -d -m 750 -o "$APP_USER" -g "$APP_GROUP" "$APP_DIR/data"
+
+cat <<EOF > "/etc/systemd/system/${SERVICE_NAME}.service"
+[Unit]
+Description=PlayrServers management API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${APP_USER}
+Group=${APP_GROUP}
+Environment=MANAGEMENT_PORT=${APP_PORT}
+Environment=MANAGEMENT_HOST=${APP_HOST}
+EnvironmentFile=-${ENV_FILE}
+WorkingDirectory=${APP_DIR}
+ExecStart=${APP_DIR}/.venv/bin/python ${APP_DIR}/main.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    cat <<'EOF' > "$ENV_FILE"
+# Environment overrides for the PlayrServers management API
+# Set MANAGEMENT_DB_PATH if you want to move the SQLite database.
+# Example:
+# MANAGEMENT_DB_PATH=/var/lib/manage-playrservers/management.sqlite3
+EOF
+    chown "$APP_USER:$APP_GROUP" "$ENV_FILE"
+    chmod 640 "$ENV_FILE"
+fi
+
+systemctl daemon-reload
+systemctl enable --now "$SERVICE_NAME"
+
+if [[ "$INSTALL_NGINX" == "1" ]]; then
+    NGINX_CONF="/etc/nginx/sites-available/${SERVICE_NAME}.conf"
+    cat <<EOF > "$NGINX_CONF"
+server {
+    listen 80;
+    server_name ${APP_DOMAIN};
+
+    location / {
+        proxy_pass http://${APP_HOST}:${APP_PORT};
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+EOF
+    ln -sf "$NGINX_CONF" "/etc/nginx/sites-enabled/${SERVICE_NAME}.conf"
+    if [[ -f /etc/nginx/sites-enabled/default ]]; then
+        rm -f /etc/nginx/sites-enabled/default
+    fi
+    nginx -t
+    systemctl reload nginx
+fi
+
+cat <<EOF
+Installation complete.
+The API service is running as ${SERVICE_NAME} and listening on http://${APP_HOST}:${APP_PORT}.
+If nginx is enabled, point DNS for ${APP_DOMAIN} to this host and add TLS using certbot.
+EOF


### PR DESCRIPTION
## Summary
- add SQLite persistence with per-user API keys, agents, and FastAPI endpoints for VM lifecycle control
- update SSH stack, auth, and runtime configuration to use inline keys and env-driven host/port settings
- document the new workflow and provide an Ubuntu 24.04 installation script that sets up systemd and nginx proxying

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cd0362da248331a0d8733c82eb5f45