### PR TITLE
Run API and management interface on separate ports

### DIFF
--- a/app/management.py
+++ b/app/management.py
@@ -11,7 +11,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 
-from .database import Database
+from .database import Database, resolve_database_path
 from .models import User
 
 
@@ -20,11 +20,19 @@ TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 
 def create_app(
     *,
-    database: Database,
+    database: Optional[Database] = None,
     api_base_url: Optional[str] = None,
     session_secret: Optional[str] = None,
+    initialize_database: bool = False,
 ) -> FastAPI:
     """Create the management web application."""
+
+    if database is None:
+        db_path = resolve_database_path(os.getenv("MANAGEMENT_DB_PATH"))
+        database = Database(db_path)
+        database.initialize()
+    elif initialize_database:
+        database.initialize()
 
     if session_secret is None:
         session_secret = os.getenv("MANAGEMENT_SESSION_SECRET")

--- a/app/templates/api_key.html
+++ b/app/templates/api_key.html
@@ -46,7 +46,8 @@ curl -X POST "$API_BASE_URL/agents" \
 </code></pre>
 
     <p class="muted">Replace the placeholder values with your environment. Cloudflare (or another
-    reverse proxy) should route <code>api.playrservers.com</code> traffic to this service's <code>/api</code> mount.</p>
+    reverse proxy) should route <code>api.playrservers.com</code> traffic to the dedicated API listener (configured via
+    <code>MANAGEMENT_API_PORT</code>, <code>8001</code> by default).</p>
 
     <form method="post" action="{{ request.url_for('rotate_api_key') }}" style="margin-top: 2rem;">
         <button type="submit" class="button">Rotate API key</button>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -9,7 +9,8 @@
         <code>{{ api_base_url }}</code>
         <p class="muted" style="margin-top: 0.75rem;">
             Requests from remote agents must target the API host above. Configure your reverse proxy (Cloudflare recommended) to
-            route <code>api.playrservers.com</code> traffic to the `/api` mount of this service.
+            route <code>api.playrservers.com</code> traffic to the dedicated API listener (configured via
+            <code>MANAGEMENT_API_PORT</code>, <code>8001</code> by default).
         </p>
     </div>
     <p>Rotate and retrieve your API credentials from the secure key page. The management interface is separate from the

--- a/main.py
+++ b/main.py
@@ -1,9 +1,18 @@
-"""Entry point for running the management API."""
+"""Entry point for running the management API and UI on separate ports."""
 from __future__ import annotations
 
+import logging
+import multiprocessing
 import os
+import signal
+import sys
+import threading
 
 import uvicorn
+
+from app.database import Database, resolve_database_path
+
+logger = logging.getLogger("playrservers.main")
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -13,9 +22,105 @@ def _env_flag(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _env_str(name: str, default: str) -> str:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    stripped = value.strip()
+    return stripped or default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:  # pragma: no cover - guards against misconfiguration
+        raise SystemExit(f"{name} must be an integer (got {raw!r})") from exc
+
+
+def _serve(app_path: str, host: str, port: int, reload_enabled: bool, workers: int) -> None:
+    uvicorn.run(
+        app_path,
+        host=host,
+        port=port,
+        reload=reload_enabled,
+        workers=workers,
+        factory=True,
+    )
+
+
+def _terminate_process(name: str, process: multiprocessing.Process) -> None:
+    if not process.is_alive():
+        return
+    logger.info("Stopping %s server", name)
+    process.terminate()
+    process.join(timeout=5)
+    if process.is_alive():
+        logger.warning("Force killing %s server", name)
+        process.kill()
+        process.join()
+
+
 if __name__ == "__main__":
-    host = os.getenv("MANAGEMENT_HOST", "0.0.0.0")
-    port = int(os.getenv("MANAGEMENT_PORT", "8000"))
-    workers = int(os.getenv("MANAGEMENT_WORKERS", "1"))
-    reload = _env_flag("MANAGEMENT_RELOAD", False)
-    uvicorn.run("app:app", host=host, port=port, reload=reload, workers=workers)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    host = _env_str("MANAGEMENT_HOST", "0.0.0.0")
+    port = _env_int("MANAGEMENT_PORT", 8000)
+    api_host = _env_str("MANAGEMENT_API_HOST", host)
+    api_port = _env_int("MANAGEMENT_API_PORT", 8001)
+    workers = _env_int("MANAGEMENT_WORKERS", 1)
+    reload_enabled = _env_flag("MANAGEMENT_RELOAD", False)
+
+    db_path = resolve_database_path(os.getenv("MANAGEMENT_DB_PATH"))
+    Database(db_path).initialize()
+
+    stop_event = threading.Event()
+
+    def _handle_signal(signum: int, frame) -> None:  # type: ignore[override]
+        logger.info("Received signal %s; shutting down servers", signum)
+        stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, _handle_signal)
+
+    endpoints = [
+        ("management", "app.management:create_app", host, port),
+        ("api", "app.api:create_app", api_host, api_port),
+    ]
+
+    processes: list[tuple[str, str, int, multiprocessing.Process]] = []
+    exit_code = 0
+
+    try:
+        for name, app_path, listen_host, listen_port in endpoints:
+            process = multiprocessing.Process(
+                target=_serve,
+                args=(app_path, listen_host, listen_port, reload_enabled, workers),
+                name=f"{name}-server",
+            )
+            processes.append((name, listen_host, listen_port, process))
+            logger.info("Starting %s server on %s:%d", name, listen_host, listen_port)
+            process.start()
+
+        while not stop_event.is_set():
+            all_running = True
+            for name, listen_host, listen_port, process in processes:
+                process.join(timeout=0.5)
+                if process.exitcode is not None:
+                    all_running = False
+                    if process.exitcode != 0:
+                        logger.error("%s server exited with code %s", name, process.exitcode)
+                        exit_code = process.exitcode if process.exitcode and process.exitcode > 0 else 1
+                    else:
+                        logger.info("%s server stopped", name)
+                    stop_event.set()
+                    break
+            if not all_running:
+                break
+    finally:
+        stop_event.set()
+        for name, _, _, process in processes:
+            _terminate_process(name, process)
+    sys.exit(exit_code)


### PR DESCRIPTION
## Summary
- launch the management UI and automation API on separate uvicorn processes with configurable ports
- allow the management application factory to initialize its own database for standalone execution
- document the new port layout and update the installer/nginx configuration along with UI copy to reflect the dedicated API listener

## Testing
- python -m compileall app main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd0beeab6c8331a6a37a40fea5e847