### PR TITLE
Add itsdangerous dependency for FastAPI stack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.110.0
+itsdangerous==2.1.2
 uvicorn[standard]==0.29.0
 paramiko==3.4.0
 PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- add a pinned itsdangerous dependency alongside the FastAPI requirements

## Testing
- pip install -r requirements.txt *(fails: unable to reach package index via proxy)*
- systemctl restart manage-playrservers.service *(fails: systemd is not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1b8fe9e0833190c69804c53f19f2