### PR TITLE
Add python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.110.0
 itsdangerous==2.1.2
+python-multipart==0.0.9
 uvicorn[standard]==0.29.0
 paramiko==3.4.0
 PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- add a pinned python-multipart dependency required for form handling

## Testing
- pip install -r requirements.txt *(fails: proxy returns 403 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1ff9ae688331b430c60e77974ddb