### PR TITLE
Allow CLI imports without FastAPI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,34 @@
-"""ASGI application entrypoint for PlayrServers."""
+"""ASGI application entrypoint for PlayrServers.
+
+The CLI utilities import :mod:`app` in order to reach the database layer, but
+those hosts might not have the FastAPI dependency installed. Importing the
+package should therefore succeed even when ``fastapi`` is missing; the ASGI app
+is only instantiated when the dependency is available.
+"""
+
 from __future__ import annotations
 
-from .application import create_application
+from typing import TYPE_CHECKING, Optional
 
-app = create_application()
+if TYPE_CHECKING:  # pragma: no cover - used only for typing
+    from fastapi import FastAPI
+
+
+def create_application(*args, **kwargs):
+    """Import the factory lazily so CLI imports do not require FastAPI."""
+
+    from .application import create_application as factory
+
+    return factory(*args, **kwargs)
+
+
+try:
+    app: Optional["FastAPI"] = create_application()
+except ModuleNotFoundError as exc:
+    if exc.name != "fastapi":
+        raise
+    # FastAPI is not installed; CLI utilities can still import app.database.
+    app = None
+
 
 __all__ = ["app", "create_application"]

--- a/tests/test_cli_import.py
+++ b/tests/test_cli_import.py
@@ -1,0 +1,42 @@
+"""Regression tests for CLI imports without the FastAPI dependency."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+
+
+class CLIImportTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        self._clear_app_modules()
+
+    @staticmethod
+    def _clear_app_modules() -> None:
+        for name in [m for m in list(sys.modules.keys()) if m == "app" or m.startswith("app.")]:
+            sys.modules.pop(name, None)
+
+    def test_import_database_without_fastapi(self) -> None:
+        """Importing app.database should succeed even if FastAPI is unavailable."""
+
+        self._clear_app_modules()
+
+        fastapi_module: types.ModuleType | None = sys.modules.pop("fastapi", None)
+        sys.modules["fastapi"] = None
+        try:
+            database_module = importlib.import_module("app.database")
+            self.assertTrue(hasattr(database_module, "Database"))
+
+            app_module = sys.modules.get("app")
+            self.assertIsNotNone(app_module)
+            self.assertTrue(hasattr(app_module, "create_application"))
+            self.assertIsNone(getattr(app_module, "app"))
+        finally:
+            sys.modules.pop("fastapi", None)
+            if fastapi_module is not None:
+                sys.modules["fastapi"] = fastapi_module
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- lazily import the application factory so app imports succeed when FastAPI is missing
- swallow the FastAPI-specific ModuleNotFoundError while still exporting the factory
- add a regression test that simulates an environment without FastAPI and verifies app.database can be imported

## Testing
- python -m unittest discover -s tests -p 'test_*.py'


------
https://chatgpt.com/codex/tasks/task_e_68cd216b9e508331adc0a83e1b895110