### PR TITLE
Update installer URL and verify service status

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ for `manage.playrservers.com`. The CLI emits colorised status banners so you
 can track progress at a glance.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/PlayrServers/Management/main/scripts/install.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/PlayrTBH/Management/main/scripts/install.sh | sudo bash
 ```
 
 Already have a clone checked out? Run the same installer locally:


### PR DESCRIPTION
## Summary
- point the installer at the public PlayrTBH/Management repository by default
- ensure the fancy installer output only reports success when the systemd service is actually running
- update the one-line install command in the README to use the public raw GitHub URL

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd30e1a3dc833197816de3c1477fdb