### PR TITLE
Fix login session cookie configuration

### DIFF
--- a/app/management.py
+++ b/app/management.py
@@ -57,11 +57,15 @@ def create_app(
     app.state.database = database
     app.state.public_api_url = api_base_url
 
-    secure_cookie = os.getenv("MANAGEMENT_SESSION_SECURE", "true").strip().lower() not in {
-        "0",
-        "false",
-        "no",
-    }
+    secure_cookie_setting = os.getenv("MANAGEMENT_SESSION_SECURE")
+    if secure_cookie_setting is None:
+        secure_cookie = False
+    else:
+        secure_cookie = secure_cookie_setting.strip().lower() not in {
+            "0",
+            "false",
+            "no",
+        }
 
     app.add_middleware(
         SessionMiddleware,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ paramiko==3.4.0
 PyYAML==6.0.1
 Jinja2==3.1.3
 passlib[bcrypt]==1.7.4
+httpx==0.27.2

--- a/tests/test_management_login.py
+++ b/tests/test_management_login.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("MANAGEMENT_SESSION_SECRET", "tests-secret-key")
+os.environ.setdefault(
+    "MANAGEMENT_DB_PATH",
+    str(Path(tempfile.gettempdir()) / "management-tests.sqlite3"),
+)
+
+from app.database import Database
+from app.management import create_app
+
+
+EMAIL = "user@example.com"
+PASSWORD = "super-secret-password"
+
+
+def test_login_redirects_to_dashboard_when_credentials_valid(tmp_path):
+    database = Database(tmp_path / "test.sqlite3")
+    database.initialize()
+    database.create_user("Test User", EMAIL, PASSWORD)
+
+    app = create_app(
+        database=database,
+        session_secret="not-so-secret",
+        api_base_url="https://example.com",
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/login",
+            data={"email": EMAIL, "password": PASSWORD},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 303
+        assert response.headers["location"].endswith("/dashboard")
+
+        follow = client.get("/dashboard", follow_redirects=False)
+        assert follow.status_code == 200


### PR DESCRIPTION
## Summary
- default to non-secure session cookies unless explicitly requested so login works in HTTP environments
- add test covering the login flow to ensure the session persists and redirect reaches the dashboard
- add httpx dependency required for FastAPI's TestClient

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd32a25da083319f7b92f003ee620f