### PR TITLE
Document one-line update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ sudo ./scripts/create_user.py "Alice Ops" alice@example.com
 The script prompts for a password and prints the initial API key once (store it
 securely; subsequent rotations occur from the web portal).
 
+## Updating an existing deployment
+
+Fetch the latest code, refresh Python dependencies, and restart the service without touching your SQLite data (so configured users and hypervisor connections remain intact):
+
+```bash
+sudo -u playrmanager git -C /opt/manage.playrservers pull --ff-only && sudo -u playrmanager /opt/manage.playrservers/.venv/bin/pip install -r /opt/manage.playrservers/requirements.txt && sudo systemctl restart manage-playrservers
+```
+
 ## Configuration
 
 The application stores its data in SQLite and exposes configuration through


### PR DESCRIPTION
## Summary
- document a safe one-line command in the README for updating the deployment without touching existing data

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cd33d6b9108331810d5be14db6a900