### PR TITLE
Update operator guidance and installer progress bar

### DIFF
--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -89,7 +89,7 @@ curl -X POST "$API_BASE_URL/agents" \
         "private_key": "$(cat /etc/playrservers/ssh/id_ed25519)"
       }'
 </code></pre>
-        <p class="muted">Route <code>{{ api_base_url }}</code> through your reverse proxy (Cloudflare or nginx) to the dedicated API listener (<code>MANAGEMENT_API_PORT</code>, <code>8001</code> by default).</p>
+        <p class="muted">The control plane operations team maintains <code>{{ api_base_url }}</code>; reference this URL when configuring agents to reach the API listener (<code>MANAGEMENT_API_PORT</code>, <code>8001</code> by default).</p>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -19,7 +19,7 @@
         <div class="grid-2">
             <section>
                 <h3 style="margin-top: 0;">Automation endpoints</h3>
-                <p>Remote agents authenticate against <code>{{ api_base_url }}</code> using your user-scoped API key. Publish the API behind Cloudflare or nginx and forward requests to the dedicated listener (<code>MANAGEMENT_API_PORT</code>, <code>8001</code> by default).</p>
+                <p>Remote agents authenticate against <code>{{ api_base_url }}</code> using your user-scoped API key. The control plane operations team keeps this endpoint available; share the base URL with anyone preparing agent deployments.</p>
                 <p class="muted">Rotate compromised keys from the <a href="{{ request.url_for('account') }}" style="color: inherit; text-decoration: underline;">account page</a>. Each rotation is shown once and persisted in the SQLite credential store.</p>
             </section>
             <section>


### PR DESCRIPTION
## Summary
- update operator-facing templates and docs to focus on agent onboarding rather than reverse proxy setup
- refresh README guidance to reflect platform-managed hosting and remove reverse proxy references
- overhaul the installer to stream status through a progress bar while logging command output

## Testing
- pytest *(fails: missing httpx dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd350e475883319378451294aa58b5