### PR TITLE
Add hypervisor diagnostics UI and update script

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -151,6 +151,11 @@
             border-color: rgba(34, 197, 94, 0.35);
             color: #bbf7d0;
         }
+        .notice.warning {
+            background: rgba(251, 191, 36, 0.12);
+            border-color: rgba(251, 191, 36, 0.35);
+            color: #fef08a;
+        }
         pre {
             background: rgba(15, 23, 42, 0.6);
             border-radius: 12px;
@@ -331,6 +336,31 @@
             padding: 1.5rem;
             color: var(--muted);
             background: rgba(15, 23, 42, 0.4);
+        }
+        .host-info-grid {
+            display: grid;
+            gap: 1.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+        dl.stat-list {
+            margin: 0;
+        }
+        dl.stat-list > div {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 0.4rem 0;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+        }
+        dl.stat-list > div:last-child {
+            border-bottom: none;
+        }
+        dl.stat-list dt {
+            font-weight: 600;
+        }
+        dl.stat-list dd {
+            margin: 0;
+            color: var(--muted);
         }
         .status-dot {
             width: 8px;

--- a/app/templates/management.html
+++ b/app/templates/management.html
@@ -110,6 +110,48 @@
 
     <div class="card">
         <div class="section-header">
+            <h2>Host diagnostics</h2>
+            <span class="badge" id="host-info-timestamp">{% if selected_agent %}Awaiting data{% else %}Idle{% endif %}</span>
+        </div>
+        <div id="host-info-placeholder" class="placeholder-box">
+            {% if not agents %}
+                Register a hypervisor to monitor its performance metrics.
+            {% elif not selected_agent %}
+                Select a hypervisor to view system metrics.
+            {% else %}
+                Collecting host diagnostics…
+            {% endif %}
+        </div>
+        <div id="host-info-section" style="display: none;">
+            <div id="host-info-message" class="notice" style="display: none;"></div>
+            <div class="host-info-grid">
+                <div>
+                    <h3>System facts</h3>
+                    <dl class="stat-list">
+                        <div><dt>Hostname</dt><dd id="host-system-hostname">—</dd></div>
+                        <div><dt>Kernel</dt><dd id="host-kernel">—</dd></div>
+                        <div><dt>SSH user</dt><dd id="host-system-user">—</dd></div>
+                        <div><dt>CPU model</dt><dd id="host-cpu-model">—</dd></div>
+                        <div><dt>CPU(s)</dt><dd id="host-cpu-count">—</dd></div>
+                        <div><dt>CPU frequency</dt><dd id="host-cpu-frequency">—</dd></div>
+                        <div><dt>Memory</dt><dd id="host-memory-total">—</dd></div>
+                    </dl>
+                </div>
+                <div>
+                    <h3>Performance</h3>
+                    <dl class="stat-list">
+                        <div><dt>Load avg (1/5/15m)</dt><dd id="host-load">—</dd></div>
+                        <div><dt>Memory usage</dt><dd id="host-memory-usage">—</dd></div>
+                        <div><dt>Memory available</dt><dd id="host-memory-available">—</dd></div>
+                        <div><dt>Collected</dt><dd id="host-info-updated">—</dd></div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="section-header">
             <h2>Direct SSH console</h2>
             <span class="badge warning">Operator access</span>
         </div>
@@ -166,6 +208,23 @@
     const sshCommand = document.getElementById('ssh-command');
     const sshSection = document.getElementById('ssh-section');
     const sshPlaceholder = document.getElementById('ssh-placeholder');
+    const hostInfoPlaceholder = document.getElementById('host-info-placeholder');
+    const hostInfoSection = document.getElementById('host-info-section');
+    const hostInfoMessage = document.getElementById('host-info-message');
+    const hostInfoTimestamp = document.getElementById('host-info-timestamp');
+    const hostSystemHostname = document.getElementById('host-system-hostname');
+    const hostSystemUser = document.getElementById('host-system-user');
+    const hostKernel = document.getElementById('host-kernel');
+    const hostCpuModel = document.getElementById('host-cpu-model');
+    const hostCpuCount = document.getElementById('host-cpu-count');
+    const hostCpuFrequency = document.getElementById('host-cpu-frequency');
+    const hostMemoryTotal = document.getElementById('host-memory-total');
+    const hostMemoryUsage = document.getElementById('host-memory-usage');
+    const hostMemoryAvailable = document.getElementById('host-memory-available');
+    const hostInfoUpdated = document.getElementById('host-info-updated');
+    const hostLoad = document.getElementById('host-load');
+
+    let hostInfoTimer = null;
 
     function buildUrl(template, agentId, vmName, action) {
         let url = template.replace('/0/', '/' + agentId + '/');
@@ -176,6 +235,280 @@
             url = url.replace('__ACTION__', action);
         }
         return url;
+    }
+
+    function clearHostInfoTimer() {
+        if (hostInfoTimer !== null) {
+            clearTimeout(hostInfoTimer);
+            hostInfoTimer = null;
+        }
+    }
+
+    function isFiniteNumber(value) {
+        return typeof value === 'number' && Number.isFinite(value);
+    }
+
+    function humanizeBytes(bytes) {
+        if (!isFiniteNumber(bytes)) {
+            return 'Unavailable';
+        }
+        const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+        let index = 0;
+        let value = bytes;
+        while (value >= 1024 && index < units.length - 1) {
+            value /= 1024;
+            index += 1;
+        }
+        const precision = value >= 10 || index === 0 ? 0 : 1;
+        return `${value.toFixed(precision)} ${units[index]}`;
+    }
+
+    function parseNodeinfoMemory(value) {
+        if (typeof value !== 'string') {
+            return null;
+        }
+        const match = value.match(/([0-9.]+)\s*KiB/i);
+        if (!match) {
+            return null;
+        }
+        const parsed = parseFloat(match[1]);
+        if (!Number.isFinite(parsed)) {
+            return null;
+        }
+        return parsed * 1024;
+    }
+
+    function formatNodeinfoMemory(value) {
+        const bytes = parseNodeinfoMemory(value);
+        if (bytes === null) {
+            return value || 'Unavailable';
+        }
+        return humanizeBytes(bytes);
+    }
+
+    function formatLoadAverage(load) {
+        if (!load || !isFiniteNumber(load.one) || !isFiniteNumber(load.five) || !isFiniteNumber(load.fifteen)) {
+            return 'Unavailable';
+        }
+        return `${load.one.toFixed(2)} / ${load.five.toFixed(2)} / ${load.fifteen.toFixed(2)}`;
+    }
+
+    function formatMemoryUsage(memory) {
+        if (!memory || !isFiniteNumber(memory.total_bytes) || !isFiniteNumber(memory.used_bytes)) {
+            return 'Unavailable';
+        }
+        const used = humanizeBytes(memory.used_bytes);
+        const total = humanizeBytes(memory.total_bytes);
+        const percentText = isFiniteNumber(memory.usage_percent)
+            ? ` (${memory.usage_percent.toFixed(1)}%)`
+            : '';
+        return `${used} / ${total}${percentText}`;
+    }
+
+    function resetHostInfoFields() {
+        const fields = [
+            hostSystemHostname,
+            hostSystemUser,
+            hostKernel,
+            hostCpuModel,
+            hostCpuCount,
+            hostCpuFrequency,
+            hostMemoryTotal,
+            hostMemoryUsage,
+            hostMemoryAvailable,
+            hostInfoUpdated,
+            hostLoad,
+        ];
+        fields.forEach((field) => {
+            if (field) {
+                field.textContent = '—';
+            }
+        });
+    }
+
+    function setHostInfoBadge(text) {
+        if (hostInfoTimestamp) {
+            hostInfoTimestamp.textContent = text;
+        }
+    }
+
+    function showHostInfoPlaceholder(message, badgeText = 'Idle') {
+        if (!hostInfoPlaceholder || !hostInfoSection) {
+            return;
+        }
+        clearHostInfoTimer();
+        resetHostInfoFields();
+        hostInfoPlaceholder.textContent = message;
+        hostInfoPlaceholder.style.display = '';
+        hostInfoSection.style.display = 'none';
+        if (hostInfoMessage) {
+            hostInfoMessage.textContent = '';
+            hostInfoMessage.className = 'notice';
+            hostInfoMessage.style.display = 'none';
+        }
+        setHostInfoBadge(badgeText);
+    }
+
+    function setHostInfoLoading(agent) {
+        if (!hostInfoPlaceholder || !hostInfoSection) {
+            return;
+        }
+        clearHostInfoTimer();
+        resetHostInfoFields();
+        hostInfoPlaceholder.textContent = `Collecting host diagnostics from ${agent.name}…`;
+        hostInfoPlaceholder.style.display = '';
+        hostInfoSection.style.display = 'none';
+        if (hostInfoMessage) {
+            hostInfoMessage.textContent = '';
+            hostInfoMessage.className = 'notice';
+            hostInfoMessage.style.display = 'none';
+        }
+        setHostInfoBadge('Loading…');
+    }
+
+    function showHostInfoError(message) {
+        if (!hostInfoSection || !hostInfoPlaceholder) {
+            return;
+        }
+        clearHostInfoTimer();
+        resetHostInfoFields();
+        hostInfoSection.style.display = '';
+        hostInfoPlaceholder.style.display = 'none';
+        if (hostInfoMessage) {
+            hostInfoMessage.textContent = message;
+            hostInfoMessage.className = 'notice danger';
+            hostInfoMessage.style.display = '';
+        }
+        setHostInfoBadge('Error');
+        if (hostInfoUpdated) {
+            hostInfoUpdated.textContent = '—';
+        }
+    }
+
+    function renderHostInfo(payload) {
+        if (!hostInfoSection || !hostInfoPlaceholder) {
+            return;
+        }
+        resetHostInfoFields();
+        hostInfoPlaceholder.style.display = 'none';
+        hostInfoSection.style.display = '';
+
+        if (hostInfoMessage) {
+            if (Array.isArray(payload.warnings) && payload.warnings.length) {
+                hostInfoMessage.textContent = payload.warnings.join(' ');
+                hostInfoMessage.className = 'notice warning';
+                hostInfoMessage.style.display = '';
+            } else {
+                hostInfoMessage.textContent = '';
+                hostInfoMessage.className = 'notice';
+                hostInfoMessage.style.display = 'none';
+            }
+        }
+
+        const system = payload.system || {};
+        if (hostSystemHostname) {
+            hostSystemHostname.textContent = system.hostname || '—';
+        }
+        if (hostSystemUser) {
+            hostSystemUser.textContent = system.username || '—';
+        }
+        if (hostKernel) {
+            hostKernel.textContent = system.kernel || 'Unavailable';
+        }
+
+        const nodeinfo = payload.nodeinfo || {};
+        if (hostCpuModel) {
+            hostCpuModel.textContent = nodeinfo['CPU model'] || '—';
+        }
+        if (hostCpuCount) {
+            hostCpuCount.textContent = nodeinfo['CPU(s)'] || '—';
+        }
+        if (hostCpuFrequency) {
+            hostCpuFrequency.textContent = nodeinfo['CPU frequency'] || '—';
+        }
+        if (hostMemoryTotal) {
+            hostMemoryTotal.textContent = formatNodeinfoMemory(nodeinfo['Memory size']);
+        }
+
+        const performance = payload.performance || {};
+        if (hostLoad) {
+            hostLoad.textContent = formatLoadAverage(performance.load_average);
+        }
+        const memory = performance.memory || null;
+        if (hostMemoryUsage) {
+            hostMemoryUsage.textContent = formatMemoryUsage(memory);
+        }
+        if (hostMemoryAvailable) {
+            hostMemoryAvailable.textContent = memory && isFiniteNumber(memory.available_bytes)
+                ? humanizeBytes(memory.available_bytes)
+                : 'Unavailable';
+        }
+
+        if (hostInfoUpdated) {
+            hostInfoUpdated.textContent = payload.collected_at
+                ? new Date(payload.collected_at).toLocaleString()
+                : '—';
+        }
+        if (hostInfoTimestamp) {
+            hostInfoTimestamp.textContent = payload.collected_at
+                ? `Updated ${new Date(payload.collected_at).toLocaleTimeString()}`
+                : 'Updated just now';
+        }
+    }
+
+    function scheduleHostInfoRefresh(agent) {
+        clearHostInfoTimer();
+        if (!agent || !state.endpoints.host_info) {
+            return;
+        }
+        hostInfoTimer = window.setTimeout(() => {
+            if (!state.selectedAgent || state.selectedAgent.id !== agent.id) {
+                return;
+            }
+            fetchHostInfo(agent, { showLoading: false });
+        }, 15000);
+    }
+
+    async function fetchHostInfo(agent, options = {}) {
+        const { showLoading = true } = options;
+
+        if (!hostInfoSection || !hostInfoPlaceholder) {
+            return;
+        }
+
+        if (!agent) {
+            const message = state.agents.length
+                ? 'Select a hypervisor to view system metrics.'
+                : 'Register a hypervisor to monitor its performance metrics.';
+            showHostInfoPlaceholder(message, 'Idle');
+            return;
+        }
+
+        if (!state.endpoints.host_info) {
+            showHostInfoError('Host diagnostics endpoint is not available.');
+            return;
+        }
+
+        if (showLoading) {
+            setHostInfoLoading(agent);
+        }
+
+        try {
+            clearHostInfoTimer();
+            const url = buildUrl(state.endpoints.host_info, agent.id);
+            const response = await fetch(url, { credentials: 'same-origin' });
+            const payload = await response.json();
+            if (payload.status !== 'ok') {
+                throw new Error(payload.message || 'Unable to retrieve host diagnostics.');
+            }
+            if (!state.selectedAgent || state.selectedAgent.id !== agent.id) {
+                return;
+            }
+            renderHostInfo(payload);
+            scheduleHostInfoRefresh(agent);
+        } catch (error) {
+            showHostInfoError(error.message || 'Unable to retrieve host diagnostics.');
+        }
     }
 
     function renderAgents() {
@@ -386,6 +719,7 @@
         updateAgentLabel(agent);
         updateSshSection(agent);
         fetchVms(agent);
+        fetchHostInfo(agent);
     }
 
     renderAgents();
@@ -393,8 +727,13 @@
     updateSshSection(state.selectedAgent);
     if (state.selectedAgent) {
         fetchVms(state.selectedAgent);
+        fetchHostInfo(state.selectedAgent);
     } else if (state.agents.length) {
         setVmStatus('Select a hypervisor to load its virtual machines.');
+        showHostInfoPlaceholder('Select a hypervisor to view system metrics.');
+    } else {
+        setVmStatus('Register a hypervisor to view its virtual machines.');
+        showHostInfoPlaceholder('Register a hypervisor to monitor its performance metrics.');
     }
 })();
 </script>

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "This updater must be run as root (try again with sudo)." >&2
+    exit 1
+fi
+
+if command -v tput >/dev/null 2>&1 && [[ -t 1 ]]; then
+    BOLD=$(tput bold)
+    RESET=$(tput sgr0)
+    CYAN=$(tput setaf 6)
+    GREEN=$(tput setaf 2)
+    YELLOW=$(tput setaf 3)
+    RED=$(tput setaf 1)
+else
+    BOLD=""
+    RESET=""
+    CYAN=""
+    GREEN=""
+    YELLOW=""
+    RED=""
+fi
+
+ICON_INFO="ℹ️"
+ICON_OK="✅"
+ICON_WARN="⚠️"
+ICON_ERROR="❌"
+
+log_info() {
+    printf "%s%s %s%s%s\n" "$CYAN" "$ICON_INFO" "$BOLD" "$1" "$RESET"
+}
+
+log_success() {
+    printf "%s%s %s%s%s\n" "$GREEN" "$ICON_OK" "$BOLD" "$1" "$RESET"
+}
+
+log_warn() {
+    printf "%s%s %s%s%s\n" "$YELLOW" "$ICON_WARN" "$BOLD" "$1" "$RESET"
+}
+
+log_error() {
+    printf "%s%s %s%s%s\n" "$RED" "$ICON_ERROR" "$BOLD" "$1" "$RESET" >&2
+}
+
+APP_DIR="${APP_DIR:-/opt/manage.playrservers}"
+APP_BRANCH="${APP_BRANCH:-main}"
+APP_REMOTE="${APP_REMOTE:-origin}"
+SERVICE_NAME="${SERVICE_NAME:-manage-playrservers}"
+VENV_PATH="${VENV_PATH:-$APP_DIR/.venv}"
+REQUIREMENTS_FILE="${REQUIREMENTS_FILE:-$APP_DIR/requirements.txt}"
+STOP_SERVICE="${STOP_SERVICE:-1}"
+SKIP_SERVICE_RESTART="${SKIP_SERVICE_RESTART:-0}"
+
+SERVICE_WAS_ACTIVE=0
+SERVICE_STOPPED=0
+
+cleanup() {
+    local exit_code=$?
+    if (( exit_code != 0 )) && (( SERVICE_STOPPED == 1 )) && command -v systemctl >/dev/null 2>&1; then
+        if [[ "$SKIP_SERVICE_RESTART" != "1" ]]; then
+            log_warn "Update failed; attempting to restart ${SERVICE_NAME}."
+            if systemctl start "$SERVICE_NAME"; then
+                log_info "${SERVICE_NAME} has been restarted after a failed update."
+            else
+                log_error "Unable to restart ${SERVICE_NAME}. Review 'journalctl -u ${SERVICE_NAME}' for details."
+            fi
+        fi
+    fi
+}
+trap cleanup EXIT
+
+log_info "Updating PlayrServers Control Plane in ${APP_DIR}"
+
+if [[ ! -d "$APP_DIR/.git" ]]; then
+    log_error "No Git repository found in ${APP_DIR}."
+    exit 1
+fi
+
+if [[ -n $(git -C "$APP_DIR" status --porcelain) ]]; then
+    log_error "Repository has uncommitted changes. Commit or stash them before updating."
+    exit 1
+fi
+
+if command -v systemctl >/dev/null 2>&1 && [[ "$STOP_SERVICE" == "1" ]]; then
+    if systemctl is-active --quiet "$SERVICE_NAME"; then
+        log_info "Stopping ${SERVICE_NAME} service."
+        systemctl stop "$SERVICE_NAME"
+        SERVICE_WAS_ACTIVE=1
+        SERVICE_STOPPED=1
+    else
+        log_info "Service ${SERVICE_NAME} is not active."
+    fi
+fi
+
+CURRENT_REV=$(git -C "$APP_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+log_info "Current revision: ${CURRENT_REV}"
+
+log_info "Fetching ${APP_REMOTE}/${APP_BRANCH}"
+git -C "$APP_DIR" fetch "$APP_REMOTE"
+git -C "$APP_DIR" checkout "$APP_BRANCH"
+git -C "$APP_DIR" pull --ff-only "$APP_REMOTE" "$APP_BRANCH"
+
+NEW_REV=$(git -C "$APP_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+if [[ "$NEW_REV" == "$CURRENT_REV" ]]; then
+    log_info "Repository already up to date (revision ${NEW_REV})."
+else
+    log_success "Repository updated to revision ${NEW_REV}."
+fi
+
+if [[ -x "$VENV_PATH/bin/pip" ]]; then
+    log_info "Updating Python dependencies."
+    "$VENV_PATH/bin/pip" install --upgrade pip
+    "$VENV_PATH/bin/pip" install -r "$REQUIREMENTS_FILE"
+else
+    log_warn "Virtual environment not found at ${VENV_PATH}; skipping dependency update."
+fi
+
+if command -v systemctl >/dev/null 2>&1 && [[ "$SKIP_SERVICE_RESTART" != "1" ]]; then
+    log_info "Reloading systemd units."
+    systemctl daemon-reload
+    if (( SERVICE_WAS_ACTIVE == 1 )); then
+        log_info "Starting ${SERVICE_NAME} service."
+        systemctl start "$SERVICE_NAME"
+        SERVICE_STOPPED=0
+        if systemctl is-active --quiet "$SERVICE_NAME"; then
+            log_success "${SERVICE_NAME} is running."
+        else
+            log_warn "${SERVICE_NAME} did not start successfully. Check 'journalctl -u ${SERVICE_NAME}'."
+        fi
+    else
+        log_info "Service ${SERVICE_NAME} was not active before the update; leaving it stopped."
+    fi
+else
+    log_warn "Systemd not available or restart skipped. Start ${SERVICE_NAME} manually if required."
+fi
+
+log_success "Update completed."

--- a/tests/test_management_host_info.py
+++ b/tests/test_management_host_info.py
@@ -1,0 +1,109 @@
+import os
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("MANAGEMENT_SESSION_SECRET", "tests-secret-key")
+
+from app.database import Database
+from app.management import create_app
+from app.ssh import CommandResult
+
+
+EMAIL = "host@example.com"
+PASSWORD = "super-secret"
+
+
+class FakeRunner:
+    def __init__(self) -> None:
+        self.commands = []
+
+    def run(self, args, timeout: int = 60) -> CommandResult:
+        self.commands.append(list(args))
+        joined = " ".join(args)
+        if joined == "virsh nodeinfo":
+            stdout = """CPU model: x86_64\nCPU(s): 4\nCPU frequency: 2400 MHz\nMemory size: 16777216 KiB\n"""
+            return CommandResult(command=args, exit_status=0, stdout=stdout, stderr="")
+        if joined == "uname -sr":
+            return CommandResult(command=args, exit_status=0, stdout="Linux 6.1.0\n", stderr="")
+        if joined == "cat /proc/loadavg":
+            return CommandResult(command=args, exit_status=0, stdout="0.25 0.50 0.75 1/234 5678\n", stderr="")
+        if joined == "free -b":
+            stdout = (
+                "              total        used        free      shared  buff/cache   available\n"
+                "Mem:     16777216000  4294967296  2147483648   536870912  10200547328  1234567890\n"
+                "Swap:     2147483648          0  2147483648\n"
+            )
+            return CommandResult(command=args, exit_status=0, stdout=stdout, stderr="")
+        raise AssertionError(f"Unexpected command: {args}")
+
+
+def test_host_info_endpoint_returns_metrics(tmp_path):
+    database = Database(tmp_path / "management.sqlite3")
+    database.initialize()
+    user, _ = database.create_user("Observer", EMAIL, PASSWORD)
+    agent = database.create_agent(
+        user.id,
+        name="hypervisor-01",
+        hostname="hv.internal",
+        port=22,
+        username="qemu",
+        private_key="dummy-key",
+        private_key_passphrase=None,
+        allow_unknown_hosts=False,
+        known_hosts_path=None,
+    )
+
+    app = create_app(
+        database=database,
+        session_secret="tests-secret", 
+        api_base_url="https://example.com",
+    )
+
+    runner = FakeRunner()
+
+    def runner_factory(requested_agent):
+        assert requested_agent.id == agent.id
+        return runner
+
+    app.state.ssh_runner_factory = runner_factory
+
+    with TestClient(app) as client:
+        login = client.post(
+            "/login",
+            data={"email": EMAIL, "password": PASSWORD},
+            follow_redirects=False,
+        )
+        assert login.status_code == 303
+
+        response = client.get(f"/management/agents/{agent.id}/host-info")
+        assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["system"]["hostname"] == agent.hostname
+    assert payload["system"]["username"] == agent.username
+    assert payload["nodeinfo"]["CPU(s)"] == "4"
+    assert payload["nodeinfo"]["CPU model"] == "x86_64"
+
+    load = payload["performance"]["load_average"]
+    assert load == {"one": 0.25, "five": 0.5, "fifteen": 0.75}
+
+    memory = payload["performance"]["memory"]
+    assert memory["total_bytes"] == 16777216000
+    assert memory["used_bytes"] == 4294967296
+    assert memory["available_bytes"] == 1234567890
+    assert memory["usage_percent"] == 25.6
+
+    assert payload["collected_at"].endswith("Z")
+    assert runner.commands == [
+        ["virsh", "nodeinfo"],
+        ["uname", "-sr"],
+        ["cat", "/proc/loadavg"],
+        ["free", "-b"],
+    ]


### PR DESCRIPTION
## Summary
- expose host diagnostics data from the management service, including load averages and memory usage
- expand the management UI with a host diagnostics card, live SSH/VM switching improvements, and supporting styles
- add an update.sh helper to refresh deployments in place and cover the new endpoint with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5b61b0b0833194f02c92c7f8312c