### PR TITLE
Implement browser SSH terminal streaming backend

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -186,6 +186,55 @@
             font-size: 0.85rem;
             color: var(--muted);
         }
+        .ssh-terminal-wrapper {
+            position: relative;
+            height: 320px;
+            border-radius: 12px;
+            background: rgba(15, 23, 42, 0.6);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            overflow: hidden;
+        }
+        .ssh-terminal {
+            width: 100%;
+            height: 100%;
+        }
+        .ssh-terminal-overlay {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 1.5rem;
+            background: rgba(15, 23, 42, 0.85);
+            color: var(--muted);
+            font-size: 0.95rem;
+        }
+        .ssh-controls {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            margin-top: 1rem;
+            flex-wrap: wrap;
+        }
+        .ssh-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }
+        .ssh-status {
+            font-size: 0.85rem;
+            color: var(--muted);
+        }
+        .ssh-status.error {
+            color: var(--danger);
+        }
+        .button.secondary[disabled] {
+            opacity: 0.5;
+            cursor: not-allowed;
+            border-color: rgba(148, 163, 184, 0.25);
+        }
         .stack {
             display: flex;
             flex-direction: column;
@@ -401,6 +450,7 @@
             }
         }
     </style>
+    {% block extra_head %}{% endblock %}
 </head>
 <body>
     <header>

--- a/app/templates/management.html
+++ b/app/templates/management.html
@@ -1,4 +1,7 @@
 {% extends "layout.html" %}
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
+{% endblock %}
 {% block title %}Management · PlayrServers Control Plane{% endblock %}
 {% block content %}
 <div class="stack">
@@ -159,12 +162,21 @@
             Select a hypervisor to populate SSH connection details.
         </div>
         <div id="ssh-section"{% if not selected_agent %} style="display: none;"{% endif %}>
-            <p class="muted">Launch an SSH session to the selected hypervisor or copy the ready-to-run command.</p>
-            <div class="ssh-launch">
-                <a id="ssh-link" class="button secondary" target="_blank" rel="noreferrer noopener" href="#">Open SSH session</a>
-                <code id="ssh-command"></code>
+            <p class="muted">Use the in-browser console to connect to the selected hypervisor or copy the ready-to-run SSH command.</p>
+            <div class="ssh-terminal-wrapper">
+                <div id="ssh-terminal" class="ssh-terminal"></div>
+                <div id="ssh-terminal-overlay" class="ssh-terminal-overlay">Select a hypervisor and click Connect to start a session.</div>
             </div>
-            <p class="help-text">Most desktop environments will hand the SSH URI off to your preferred terminal client.</p>
+            <div class="ssh-controls">
+                <div class="ssh-buttons">
+                    <button type="button" id="ssh-connect" class="button secondary">Connect</button>
+                    <button type="button" id="ssh-disconnect" class="button secondary" disabled>Disconnect</button>
+                    <button type="button" id="ssh-copy-command" class="button secondary">Copy SSH command</button>
+                </div>
+                <span id="ssh-terminal-status" class="ssh-status">Disconnected.</span>
+            </div>
+            <code id="ssh-command"></code>
+            <p class="help-text">Sessions authenticate using the stored automation key and run entirely within your browser.</p>
         </div>
     </div>
 
@@ -176,6 +188,8 @@
     </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
 <script id="agent-data" type="application/json">{{ agents | tojson }}</script>
 <script id="selected-agent" type="application/json">{{ selected_agent | tojson if selected_agent else 'null' }}</script>
 <script id="management-endpoints" type="application/json">{{ endpoints | tojson }}</script>
@@ -204,10 +218,15 @@
     const vmTableWrapper = document.getElementById('vm-table-wrapper');
     const vmTableBody = document.querySelector('#vm-table tbody');
     const agentLabel = document.getElementById('selected-agent-label');
-    const sshLink = document.getElementById('ssh-link');
     const sshCommand = document.getElementById('ssh-command');
     const sshSection = document.getElementById('ssh-section');
     const sshPlaceholder = document.getElementById('ssh-placeholder');
+    const sshTerminalContainer = document.getElementById('ssh-terminal');
+    const sshTerminalOverlay = document.getElementById('ssh-terminal-overlay');
+    const sshConnectButton = document.getElementById('ssh-connect');
+    const sshDisconnectButton = document.getElementById('ssh-disconnect');
+    const sshCopyButton = document.getElementById('ssh-copy-command');
+    const sshStatus = document.getElementById('ssh-terminal-status');
     const hostInfoPlaceholder = document.getElementById('host-info-placeholder');
     const hostInfoSection = document.getElementById('host-info-section');
     const hostInfoMessage = document.getElementById('host-info-message');
@@ -225,6 +244,14 @@
     const hostLoad = document.getElementById('host-load');
 
     let hostInfoTimer = null;
+    let terminal = null;
+    let fitAddon = null;
+    let terminalSocket = null;
+    let terminalAgentId = null;
+    let closingTerminalState = null;
+    const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+    const textDecoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
+    const sshCopyButtonLabel = sshCopyButton ? sshCopyButton.textContent : '';
 
     function buildUrl(template, agentId, vmName, action) {
         let url = template.replace('/0/', '/' + agentId + '/');
@@ -236,6 +263,374 @@
         }
         return url;
     }
+
+    function buildWebsocketUrl(template, agentId) {
+        if (!template) {
+            return null;
+        }
+        const replaced = template.replace('/0/', '/' + agentId + '/');
+        try {
+            const url = new URL(replaced, window.location.href);
+            url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+            return url.toString();
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function showTerminalOverlay(message) {
+        if (sshTerminalOverlay) {
+            sshTerminalOverlay.textContent = message;
+            sshTerminalOverlay.style.display = 'flex';
+        }
+    }
+
+    function hideTerminalOverlay() {
+        if (sshTerminalOverlay) {
+            sshTerminalOverlay.style.display = 'none';
+        }
+    }
+
+    function setTerminalStatus(message, isError = false) {
+        if (!sshStatus) {
+            return;
+        }
+        sshStatus.textContent = message;
+        if (isError) {
+            sshStatus.classList.add('error');
+        } else {
+            sshStatus.classList.remove('error');
+        }
+    }
+
+    function ensureTerminal() {
+        if (terminal || !sshTerminalContainer) {
+            return;
+        }
+        if (typeof window.Terminal !== 'function') {
+            showTerminalOverlay('Terminal library failed to load.');
+            setTerminalStatus('Browser terminal unavailable.', true);
+            return;
+        }
+        terminal = new window.Terminal({
+            convertEol: true,
+            cursorBlink: true,
+            fontFamily: 'JetBrains Mono, SFMono-Regular, Menlo, Consolas, "Liberation Mono", Courier, monospace',
+            fontSize: 14,
+            theme: {
+                background: '#0f172a',
+                foreground: '#f8fafc',
+            },
+        });
+        if (window.FitAddon && typeof window.FitAddon.FitAddon === 'function') {
+            fitAddon = new window.FitAddon.FitAddon();
+            terminal.loadAddon(fitAddon);
+        }
+        terminal.open(sshTerminalContainer);
+        if (fitAddon) {
+            fitAddon.fit();
+        }
+        terminal.focus();
+        terminal.onData((data) => {
+            if (terminalSocket && terminalSocket.readyState === WebSocket.OPEN) {
+                if (textEncoder) {
+                    terminalSocket.send(textEncoder.encode(data));
+                } else {
+                    terminalSocket.send(data);
+                }
+            }
+        });
+    }
+
+    function clearTerminal() {
+        if (terminal) {
+            terminal.reset();
+        }
+    }
+
+    function sendTerminalResize() {
+        if (!terminal || !terminalSocket || terminalSocket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+        const payload = {
+            type: 'resize',
+            cols: terminal.cols,
+            rows: terminal.rows,
+        };
+        try {
+            terminalSocket.send(JSON.stringify(payload));
+        } catch (_) {
+            // ignore transmission errors
+        }
+    }
+
+    function disconnectTerminal(showMessage = true) {
+        if (!terminalSocket) {
+            if (showMessage) {
+                setTerminalStatus('Disconnected.');
+                showTerminalOverlay('Session disconnected.');
+            }
+            if (sshDisconnectButton) {
+                sshDisconnectButton.setAttribute('disabled', 'true');
+            }
+            if (sshConnectButton) {
+                if (state.selectedAgent) {
+                    sshConnectButton.removeAttribute('disabled');
+                } else {
+                    sshConnectButton.setAttribute('disabled', 'true');
+                }
+            }
+            if (sshCopyButton) {
+                if (sshCopyButtonLabel) {
+                    sshCopyButton.textContent = sshCopyButtonLabel;
+                }
+                if (state.selectedAgent) {
+                    sshCopyButton.removeAttribute('disabled');
+                } else {
+                    sshCopyButton.setAttribute('disabled', 'true');
+                }
+            }
+            terminalAgentId = null;
+            return;
+        }
+        closingTerminalState = showMessage ? 'manual' : 'silent';
+        const socket = terminalSocket;
+        terminalSocket = null;
+        try {
+            if (socket.readyState === WebSocket.OPEN) {
+                socket.send(JSON.stringify({ type: 'close' }));
+            }
+            socket.close();
+        } catch (_) {
+            // ignore close failures
+        }
+    }
+
+    function connectTerminal(agent) {
+        if (!agent) {
+            return;
+        }
+
+        ensureTerminal();
+        if (!terminal) {
+            setTerminalStatus('Browser terminal unavailable.', true);
+            showTerminalOverlay('Unable to initialize terminal component.');
+            return;
+        }
+
+        if (!state.endpoints || !state.endpoints.ssh_terminal) {
+            setTerminalStatus('Terminal endpoint is not configured.', true);
+            showTerminalOverlay('Terminal endpoint is not available.');
+            return;
+        }
+
+        const websocketUrl = buildWebsocketUrl(state.endpoints.ssh_terminal, agent.id);
+        if (!websocketUrl) {
+            setTerminalStatus('Terminal endpoint is not configured.', true);
+            showTerminalOverlay('Terminal endpoint is not available.');
+            return;
+        }
+
+        if (terminalSocket) {
+            if (terminalAgentId === agent.id && terminalSocket.readyState === WebSocket.OPEN) {
+                return;
+            }
+            disconnectTerminal(false);
+        }
+
+        closingTerminalState = null;
+        terminalAgentId = agent.id;
+        setTerminalStatus(`Connecting to ${agent.hostname}…`);
+        showTerminalOverlay(`Connecting to ${agent.hostname}…`);
+
+        if (sshConnectButton) {
+            sshConnectButton.setAttribute('disabled', 'true');
+        }
+        if (sshDisconnectButton) {
+            sshDisconnectButton.removeAttribute('disabled');
+        }
+        if (sshCopyButton) {
+            sshCopyButton.removeAttribute('disabled');
+        }
+
+        clearTerminal();
+
+        try {
+            terminalSocket = new WebSocket(websocketUrl);
+        } catch (_) {
+            terminalSocket = null;
+            setTerminalStatus('Failed to connect.', true);
+            showTerminalOverlay('Failed to establish SSH session.');
+            if (sshConnectButton) {
+                sshConnectButton.removeAttribute('disabled');
+            }
+            if (sshDisconnectButton) {
+                sshDisconnectButton.setAttribute('disabled', 'true');
+            }
+            return;
+        }
+
+        terminalSocket.binaryType = 'arraybuffer';
+
+        terminalSocket.addEventListener('open', () => {
+            setTerminalStatus(`Connected to ${agent.hostname}`);
+            hideTerminalOverlay();
+            if (fitAddon) {
+                fitAddon.fit();
+            }
+            sendTerminalResize();
+        });
+
+        terminalSocket.addEventListener('message', (event) => {
+            if (typeof event.data === 'string') {
+                try {
+                    const payload = JSON.parse(event.data);
+                    if (payload.type === 'status' && payload.status === 'connected') {
+                        hideTerminalOverlay();
+                        return;
+                    }
+                    if (payload.type === 'error') {
+                        setTerminalStatus(payload.message || 'SSH session error.', true);
+                        showTerminalOverlay(payload.message || 'SSH session error.');
+                    }
+                } catch (_) {
+                    // ignore non-JSON control messages
+                }
+                return;
+            }
+
+            if (event.data instanceof ArrayBuffer && terminal) {
+                let text = '';
+                if (textDecoder) {
+                    text = textDecoder.decode(event.data);
+                } else {
+                    const view = new Uint8Array(event.data);
+                    text = Array.from(view).map((code) => String.fromCharCode(code)).join('');
+                }
+                terminal.write(text);
+            }
+        });
+
+        terminalSocket.addEventListener('close', () => {
+            const mode = closingTerminalState;
+            closingTerminalState = null;
+            terminalSocket = null;
+            terminalAgentId = null;
+            if (sshDisconnectButton) {
+                sshDisconnectButton.setAttribute('disabled', 'true');
+            }
+            if (sshConnectButton) {
+                if (state.selectedAgent) {
+                    sshConnectButton.removeAttribute('disabled');
+                } else {
+                    sshConnectButton.setAttribute('disabled', 'true');
+                }
+            }
+            if (sshCopyButton) {
+                if (sshCopyButtonLabel) {
+                    sshCopyButton.textContent = sshCopyButtonLabel;
+                }
+                if (state.selectedAgent) {
+                    sshCopyButton.removeAttribute('disabled');
+                } else {
+                    sshCopyButton.setAttribute('disabled', 'true');
+                }
+            }
+            if (mode !== 'silent') {
+                setTerminalStatus('Disconnected.');
+                showTerminalOverlay('Session disconnected.');
+            }
+        });
+
+        terminalSocket.addEventListener('error', () => {
+            setTerminalStatus('Failed to connect.', true);
+            showTerminalOverlay('Failed to establish SSH session.');
+        });
+    }
+
+    if (sshConnectButton) {
+        sshConnectButton.addEventListener('click', () => {
+            if (state.selectedAgent) {
+                connectTerminal(state.selectedAgent);
+            }
+        });
+    }
+
+    if (sshDisconnectButton) {
+        sshDisconnectButton.addEventListener('click', () => {
+            disconnectTerminal();
+        });
+    }
+
+    if (sshCopyButton) {
+        sshCopyButton.addEventListener('click', async () => {
+            if (!sshCommand) {
+                return;
+            }
+            const text = (sshCommand.textContent || '').trim();
+            if (!text) {
+                return;
+            }
+
+            const restoreLabel = () => {
+                if (sshCopyButtonLabel) {
+                    sshCopyButton.textContent = sshCopyButtonLabel;
+                }
+            };
+
+            const indicateCopied = () => {
+                sshCopyButton.textContent = 'Copied!';
+                window.setTimeout(() => {
+                    restoreLabel();
+                }, 1500);
+            };
+
+            try {
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(text);
+                    indicateCopied();
+                    return;
+                }
+            } catch (_) {
+                // Fallback to execCommand below
+            }
+
+            try {
+                const helper = document.createElement('textarea');
+                helper.value = text;
+                helper.style.position = 'fixed';
+                helper.style.opacity = '0';
+                helper.style.pointerEvents = 'none';
+                document.body.appendChild(helper);
+                helper.focus();
+                helper.select();
+                const successful = document.execCommand('copy');
+                document.body.removeChild(helper);
+                if (successful) {
+                    indicateCopied();
+                    return;
+                }
+            } catch (_) {
+                // ignore failures and fall through to status update
+            }
+
+            setTerminalStatus('Unable to copy command.', true);
+            window.setTimeout(() => {
+                restoreLabel();
+            }, 1500);
+        });
+    }
+
+    window.addEventListener('resize', () => {
+        if (fitAddon) {
+            fitAddon.fit();
+            sendTerminalResize();
+        }
+    });
+
+    window.addEventListener('beforeunload', () => {
+        disconnectTerminal(false);
+    });
 
     function clearHostInfoTimer() {
         if (hostInfoTimer !== null) {
@@ -568,24 +963,80 @@
     }
 
     function updateSshSection(agent) {
-        if (!sshLink || !sshCommand || !sshSection || !sshPlaceholder) {
+        if (!sshCommand || !sshSection || !sshPlaceholder) {
             return;
         }
         if (!agent) {
             sshSection.style.display = 'none';
             sshPlaceholder.style.display = '';
             sshCommand.textContent = '';
-            sshLink.href = '#';
+            disconnectTerminal(false);
+            showTerminalOverlay('Select a hypervisor and click Connect to start a session.');
+            setTerminalStatus('Disconnected.');
+            if (sshConnectButton) {
+                sshConnectButton.setAttribute('disabled', 'true');
+            }
+            if (sshDisconnectButton) {
+                sshDisconnectButton.setAttribute('disabled', 'true');
+            }
+            if (sshCopyButton) {
+                if (sshCopyButtonLabel) {
+                    sshCopyButton.textContent = sshCopyButtonLabel;
+                }
+                sshCopyButton.setAttribute('disabled', 'true');
+            }
             return;
         }
-        const sshUri = `ssh://${encodeURIComponent(agent.username)}@${agent.hostname}:${agent.port}`;
+
         const command = agent.port === 22
             ? `ssh ${agent.username}@${agent.hostname}`
             : `ssh -p ${agent.port} ${agent.username}@${agent.hostname}`;
-        sshLink.href = sshUri;
         sshCommand.textContent = command;
         sshSection.style.display = '';
         sshPlaceholder.style.display = 'none';
+
+        const connectedToAgent = Boolean(
+            terminalSocket && terminalSocket.readyState === WebSocket.OPEN && terminalAgentId === agent.id,
+        );
+
+        if (terminalAgentId !== null && terminalAgentId !== agent.id) {
+            disconnectTerminal(false);
+        }
+
+        if (connectedToAgent) {
+            hideTerminalOverlay();
+            setTerminalStatus(`Connected to ${agent.hostname}`);
+            if (sshConnectButton) {
+                sshConnectButton.setAttribute('disabled', 'true');
+            }
+            if (sshDisconnectButton) {
+                sshDisconnectButton.removeAttribute('disabled');
+            }
+        } else {
+            showTerminalOverlay(`Click Connect to open a session with ${agent.name}.`);
+            setTerminalStatus('Ready to connect.');
+            if (sshConnectButton) {
+                sshConnectButton.removeAttribute('disabled');
+            }
+            if (sshDisconnectButton) {
+                sshDisconnectButton.setAttribute('disabled', 'true');
+            }
+            clearTerminal();
+            ensureTerminal();
+            if (fitAddon) {
+                requestAnimationFrame(() => {
+                    fitAddon.fit();
+                    sendTerminalResize();
+                });
+            }
+        }
+
+        if (sshCopyButton) {
+            sshCopyButton.removeAttribute('disabled');
+            if (sshCopyButtonLabel) {
+                sshCopyButton.textContent = sshCopyButtonLabel;
+            }
+        }
     }
 
     function updateAgentLabel(agent) {

--- a/tests/test_management_terminal.py
+++ b/tests/test_management_terminal.py
@@ -1,0 +1,156 @@
+import json
+import os
+import queue
+import sys
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("MANAGEMENT_SESSION_SECRET", "tests-secret-key")
+
+from app.database import Database
+from app.management import create_app
+
+
+EMAIL = "terminal@example.com"
+PASSWORD = "super-secret"
+
+
+class DummyChannel:
+    def __init__(self) -> None:
+        self.sent = []
+        self.resizes = []
+        self.closed = False
+        self.send_event = threading.Event()
+        self.resize_event = threading.Event()
+        self._queue = queue.Queue()
+
+    def queue_data(self, data: bytes) -> None:
+        self._queue.put(data)
+
+    def recv(self, _size: int) -> bytes:
+        return self._queue.get()
+
+    def send(self, data: bytes) -> int:
+        payload = bytes(data)
+        self.sent.append(payload)
+        self.send_event.set()
+        return len(payload)
+
+    def resize_pty(self, width: int, height: int) -> None:
+        self.resizes.append((width, height))
+        self.resize_event.set()
+
+    def close(self) -> None:
+        if not self.closed:
+            self.closed = True
+            self._queue.put(b"")
+
+
+def test_terminal_websocket_requires_authentication(tmp_path):
+    database = Database(tmp_path / "management.sqlite3")
+    database.initialize()
+
+    user, _ = database.create_user("Operator", EMAIL, PASSWORD)
+    agent = database.create_agent(
+        user.id,
+        name="hypervisor-01",
+        hostname="hv.internal",
+        port=22,
+        username="qemu",
+        private_key="dummy",
+        private_key_passphrase=None,
+        allow_unknown_hosts=False,
+        known_hosts_path=None,
+    )
+
+    app = create_app(
+        database=database,
+        session_secret="tests-secret",
+        api_base_url="https://example.com",
+    )
+
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect(f"/management/agents/{agent.id}/terminal"):
+                pass
+        assert excinfo.value.code == 4401
+
+
+def test_terminal_websocket_streams_data(tmp_path):
+    database = Database(tmp_path / "management.sqlite3")
+    database.initialize()
+
+    user, _ = database.create_user("Operator", EMAIL, PASSWORD)
+    agent = database.create_agent(
+        user.id,
+        name="hypervisor-01",
+        hostname="hv.internal",
+        port=22,
+        username="qemu",
+        private_key="dummy",
+        private_key_passphrase=None,
+        allow_unknown_hosts=True,
+        known_hosts_path=None,
+    )
+
+    app = create_app(
+        database=database,
+        session_secret="tests-secret",
+        api_base_url="https://example.com",
+    )
+
+    channels: list[DummyChannel] = []
+
+    def terminal_factory(requested_agent):
+        assert requested_agent.id == agent.id
+        channel = DummyChannel()
+        channels.append(channel)
+
+        @contextmanager
+        def manager():
+            try:
+                yield channel
+            finally:
+                channel.close()
+
+        return manager()
+
+    app.state.ssh_terminal_factory = terminal_factory
+
+    with TestClient(app) as client:
+        login = client.post(
+            "/login",
+            data={"email": EMAIL, "password": PASSWORD},
+            follow_redirects=False,
+        )
+        assert login.status_code == 303
+
+        with client.websocket_connect(f"/management/agents/{agent.id}/terminal") as websocket:
+            message = websocket.receive_json()
+            assert message["type"] == "status"
+            assert message["status"] == "connected"
+
+            channel = channels[0]
+            channel.queue_data(b"welcome\n")
+            assert websocket.receive_bytes() == b"welcome\n"
+
+            websocket.send_bytes(b"ls\n")
+            assert channel.send_event.wait(timeout=1)
+            assert channel.sent[-1] == b"ls\n"
+
+            websocket.send_text(json.dumps({"type": "resize", "cols": 120, "rows": 40}))
+            assert channel.resize_event.wait(timeout=1)
+            assert channel.resizes[-1] == (120, 40)
+            websocket.send_text(json.dumps({"type": "close"}))
+
+        assert channel.closed is True
+

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -1,0 +1,136 @@
+import os
+import sys
+from pathlib import Path
+
+import paramiko
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("MANAGEMENT_SESSION_SECRET", "tests-secret-key")
+
+from app import ssh as ssh_module
+from app.ssh import SSHClientFactory, SSHTarget, SSHError
+
+
+class DummyChannel:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_target() -> SSHTarget:
+    return SSHTarget(
+        hostname="example.com",
+        port=22,
+        username="root",
+        private_key="dummy",
+    )
+
+
+def test_connect_unknown_host_error(monkeypatch):
+    factory = SSHClientFactory(_make_target())
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def load_host_keys(self, *_args, **_kwargs) -> None:
+            pass
+
+        def load_system_host_keys(self) -> None:
+            pass
+
+        def set_missing_host_key_policy(self, _policy) -> None:
+            pass
+
+        def connect(self, **_kwargs) -> None:
+            raise paramiko.SSHException("Server 'example.com' not found in known_hosts")
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(paramiko, "SSHClient", DummyClient)
+    monkeypatch.setattr(ssh_module, "_load_private_key", lambda _key, _passphrase: object())
+
+    with pytest.raises(SSHError) as excinfo:
+        with factory.connect():
+            pass
+
+    assert "Add the host to the configured known hosts file" in str(excinfo.value)
+
+
+def test_open_shell_propagates_error(monkeypatch):
+    factory = SSHClientFactory(_make_target())
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def load_host_keys(self, *_args, **_kwargs) -> None:
+            pass
+
+        def load_system_host_keys(self) -> None:
+            pass
+
+        def set_missing_host_key_policy(self, _policy) -> None:
+            pass
+
+        def connect(self, **_kwargs) -> None:
+            pass
+
+        def invoke_shell(self, **_kwargs):
+            raise paramiko.SSHException("no shell")
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(paramiko, "SSHClient", DummyClient)
+    monkeypatch.setattr(ssh_module, "_load_private_key", lambda _key, _passphrase: object())
+
+    with pytest.raises(SSHError) as excinfo:
+        with factory.open_shell():
+            pass
+
+    assert "Failed to open an interactive shell" in str(excinfo.value)
+
+
+def test_open_shell_closes_channel(monkeypatch):
+    factory = SSHClientFactory(_make_target())
+
+    channel = DummyChannel()
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def load_host_keys(self, *_args, **_kwargs) -> None:
+            pass
+
+        def load_system_host_keys(self) -> None:
+            pass
+
+        def set_missing_host_key_policy(self, _policy) -> None:
+            pass
+
+        def connect(self, **_kwargs) -> None:
+            pass
+
+        def invoke_shell(self, **_kwargs):
+            return channel
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(paramiko, "SSHClient", DummyClient)
+    monkeypatch.setattr(ssh_module, "_load_private_key", lambda _key, _passphrase: object())
+
+    with factory.open_shell() as opened:
+        assert opened is channel
+
+    assert channel.closed is True
+


### PR DESCRIPTION
## Summary
- add a websocket terminal endpoint with streaming logic for browser SSH sessions
- improve SSH client errors and expose an open_shell context manager
- update the management template to use the browser terminal flow and add unit tests for the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd6809810883319387d8530f4afc72