### PR TITLE
Add guided VM deployment workflows and guest console

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ infrastructure is maintained separately by the platform team.
   including hostnames, SSH ports, and host verification preferences.
 - 🧠 **VM lifecycle API** – trigger `start`, `shutdown`, `destroy`, `reboot`, or
   `dominfo` via secure HTTP calls.
+- 🧰 **Guided VM deployments** – bootstrap Ubuntu 24.04 LTS and Windows Server
+  2022 guests remotely, complete with default automation credentials.
 - 🗄️ **SQLite persistence** – all profiles, agents, and keys are stored locally
   in `data/management.sqlite3` by default.
 
@@ -129,6 +131,37 @@ exposes three primary workflows:
 
 Session cookies are signed with `MANAGEMENT_SESSION_SECRET` and marked
 `Secure`/`SameSite=Lax` so they are only transmitted over HTTPS.
+
+## Guided VM deployments
+
+With at least one hypervisor agent registered, the management dashboard can
+bootstrap new guests end-to-end from the **Deploy a virtual machine** panel.
+Select an operating system profile, adjust sizing, and the portal will download
+the installer, prepare cloud-init or unattended media, and run `virt-install`
+over SSH. The UI highlights the default credentials so operators can hand off
+access immediately after provisioning.
+
+### Supported profiles
+
+- **Ubuntu Server 24.04 LTS** – streams the official cloud image from
+  [ubuntu.com](https://ubuntu.com/download/server), seeds a `playradmin` account
+  via cloud-init, and defaults to 4 GiB RAM, 2 vCPUs, and a 40 GiB disk.
+- **Windows Server 2022 Datacenter (Evaluation)** – downloads the Microsoft
+  evaluation ISO, generates an `Autounattend.xml`, and mounts it alongside the
+  installer. A `playradmin` administrator account is created with the
+  pre-configured password `PlayrServers!23`.
+
+> **Note:** Windows automation requires an ISO authoring utility (`genisoimage`,
+> `mkisofs`, or `xorrisofs`) to be present on the hypervisor so the unattended
+> media can be generated. The evaluation ISO is subject to Microsoft's licensing
+> terms and expires unless activated.
+
+## Browser-based VM console
+
+Each VM entry now includes a **Console** button that opens a streaming `virsh
+console` session directly in the browser. Connections use the same stored SSH
+credentials as other agent workflows and can be released with <kbd>Ctrl</kbd> +
+<kbd>]</kbd>.
 
 ## API Overview
 

--- a/app/qemu.py
+++ b/app/qemu.py
@@ -1,8 +1,13 @@
 """Abstractions for controlling QEMU/KVM instances using virsh."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import List
+from __future__ import annotations
+
+import re
+import shlex
+import textwrap
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Sequence
 
 from .ssh import CommandResult, SSHCommandRunner, SSHError
 
@@ -20,6 +25,353 @@ class VMInfo:
     name: str
     state: str
     id: str | None
+
+
+ScriptBuilder = Callable[[str, int, int, int], str]
+
+
+@dataclass(frozen=True)
+class VMDeploymentProfile:
+    """Describes a turn-key VM deployment recipe."""
+
+    id: str
+    name: str
+    description: str
+    default_username: str
+    default_password: str
+    default_memory_mb: int
+    default_vcpus: int
+    default_disk_gb: int
+    download_url: str
+    source_url: str
+    os_variant: str
+    _builder: ScriptBuilder = field(repr=False)
+    notes: str | None = None
+    timeout_seconds: int = 900
+
+    def build_script(self, vm_name: str, memory_mb: int, vcpus: int, disk_gb: int) -> str:
+        return self._builder(vm_name, memory_mb, vcpus, disk_gb)
+
+    def to_public_dict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "default_username": self.default_username,
+            "default_password": self.default_password,
+            "default_memory_mb": self.default_memory_mb,
+            "default_vcpus": self.default_vcpus,
+            "default_disk_gb": self.default_disk_gb,
+            "download_url": self.download_url,
+            "source_url": self.source_url,
+            "os_variant": self.os_variant,
+            "notes": self.notes,
+        }
+
+
+IMAGE_ROOT = "/var/lib/libvirt/images/playrservers"
+
+
+def _sanitize_vm_name(name: str) -> str:
+    cleaned = name.strip()
+    if not cleaned:
+        raise ValueError("Virtual machine name must not be empty.")
+    if not re.match(r"^[A-Za-z0-9._-]+$", cleaned):
+        raise ValueError("Virtual machine name may only include letters, numbers, dots, dashes, and underscores.")
+    return cleaned
+
+
+def _render_ubuntu_deployment_script(vm_name: str, memory_mb: int, vcpus: int, disk_gb: int) -> str:
+    image_path = f"{IMAGE_ROOT}/cloud/noble-server-cloudimg-amd64.img"
+    disk_path = f"{IMAGE_ROOT}/{vm_name}.qcow2"
+    seed_dir = f"{IMAGE_ROOT}/seed/{vm_name}"
+    user_data = f"{seed_dir}/user-data"
+    meta_data = f"{seed_dir}/meta-data"
+    script = f"""
+set -euo pipefail
+
+VM_NAME={shlex.quote(vm_name)}
+IMAGES_DIR={shlex.quote(IMAGE_ROOT)}
+BASE_IMAGE={shlex.quote(image_path)}
+DISK_IMAGE={shlex.quote(disk_path)}
+SEED_DIR={shlex.quote(seed_dir)}
+USER_DATA={shlex.quote(user_data)}
+META_DATA={shlex.quote(meta_data)}
+DOWNLOAD_URL={shlex.quote('https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img')}
+
+mkdir -p "$IMAGES_DIR" "$IMAGES_DIR/cloud" "$IMAGES_DIR/seed"
+
+if virsh dominfo "$VM_NAME" >/dev/null 2>&1; then
+    echo "Virtual machine '$VM_NAME' already exists." >&2
+    exit 50
+fi
+
+if [ -e "$DISK_IMAGE" ]; then
+    echo "Disk image $DISK_IMAGE already exists." >&2
+    exit 51
+fi
+
+if [ ! -f "$BASE_IMAGE" ]; then
+    tmpfile=$(mktemp "${{BASE_IMAGE}}.XXXX")
+    curl -L --fail --silent --show-error -o "$tmpfile" "$DOWNLOAD_URL"
+    mv "$tmpfile" "$BASE_IMAGE"
+fi
+
+qemu-img create -f qcow2 -F qcow2 -b "$BASE_IMAGE" "$DISK_IMAGE" {disk_gb}G
+
+mkdir -p "$SEED_DIR"
+cat <<'EOF' > "$USER_DATA"
+#cloud-config
+users:
+  - name: playradmin
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: sudo
+    shell: /bin/bash
+    lock_passwd: false
+chpasswd:
+  expire: false
+  list: |
+    playradmin:PlayrServers!23
+ssh_pwauth: true
+EOF
+
+cat <<'EOF' > "$META_DATA"
+instance-id: $VM_NAME
+local-hostname: $VM_NAME
+EOF
+
+virt-install \
+  --name "$VM_NAME" \
+  --memory {memory_mb} \
+  --vcpus {vcpus} \
+  --disk path="$DISK_IMAGE",format=qcow2 \
+  --import \
+  --os-variant ubuntu24.04 \
+  --graphics spice \
+  --network network=default \
+  --cloud-init user-data="$USER_DATA",meta-data="$META_DATA" \
+  --noautoconsole \
+  --wait 0
+"""
+    return textwrap.dedent(script).strip()
+
+
+def _render_windows_deployment_script(vm_name: str, memory_mb: int, vcpus: int, disk_gb: int) -> str:
+    iso_path = f"{IMAGE_ROOT}/iso/windows-server-2022.iso"
+    disk_path = f"{IMAGE_ROOT}/{vm_name}.qcow2"
+    unattend_dir = f"{IMAGE_ROOT}/unattend/{vm_name}"
+    unattend_xml = f"{unattend_dir}/Autounattend.xml"
+    unattend_iso = f"{unattend_dir}/autounattend.iso"
+    download_url = "https://software-download.microsoft.com/download/pr/20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso"
+    script = f"""
+set -euo pipefail
+
+VM_NAME={shlex.quote(vm_name)}
+IMAGES_DIR={shlex.quote(IMAGE_ROOT)}
+ISO_STORE={shlex.quote(IMAGE_ROOT + '/iso')}
+ISO_PATH={shlex.quote(iso_path)}
+DISK_IMAGE={shlex.quote(disk_path)}
+UNATTEND_DIR={shlex.quote(unattend_dir)}
+UNATTEND_XML={shlex.quote(unattend_xml)}
+UNATTEND_ISO={shlex.quote(unattend_iso)}
+DOWNLOAD_URL={shlex.quote(download_url)}
+
+mkdir -p "$IMAGES_DIR" "$ISO_STORE" "$UNATTEND_DIR"
+
+if virsh dominfo "$VM_NAME" >/dev/null 2>&1; then
+    echo "Virtual machine '$VM_NAME' already exists." >&2
+    exit 50
+fi
+
+if [ -e "$DISK_IMAGE" ]; then
+    echo "Disk image $DISK_IMAGE already exists." >&2
+    exit 51
+fi
+
+if [ ! -f "$ISO_PATH" ]; then
+    tmpfile=$(mktemp "${{ISO_PATH}}.XXXX")
+    curl -L --fail --silent --show-error -o "$tmpfile" "$DOWNLOAD_URL"
+    mv "$tmpfile" "$ISO_PATH"
+fi
+
+qemu-img create -f qcow2 "$DISK_IMAGE" {disk_gb}G
+
+cat > "$UNATTEND_XML" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>Primary</Type>
+              <Size>500</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Format>NTFS</Format>
+              <Label>System</Label>
+              <Letter>C</Letter>
+              <Active>true</Active>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+              <Format>NTFS</Format>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+        <WillShowUI>OnError</WillShowUI>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>2</PartitionID>
+          </InstallTo>
+          <InstallToAvailablePartition>true</InstallToAvailablePartition>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>PlayrServers</FullName>
+        <Organization>PlayrServers</Organization>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <ComputerName>*</ComputerName>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>1</ProtectYourPC>
+      </OOBE>
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>PlayrServers!23</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>playradmin</Name>
+            <DisplayName>Playr Admin</DisplayName>
+            <Group>Administrators</Group>
+            <Password>
+              <Value>PlayrServers!23</Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <RegisteredOrganization>PlayrServers</RegisteredOrganization>
+      <RegisteredOwner>PlayrServers</RegisteredOwner>
+      <TimeZone>UTC</TimeZone>
+    </component>
+  </settings>
+</unattend>
+EOF
+
+ISO_TOOL=""
+for candidate in genisoimage mkisofs xorrisofs; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    ISO_TOOL="$candidate"
+    break
+  fi
+done
+
+if [ -z "$ISO_TOOL" ]; then
+    echo "Unable to locate a utility to build ISO images (genisoimage, mkisofs, or xorrisofs)." >&2
+    exit 52
+fi
+
+"$ISO_TOOL" -quiet -o "$UNATTEND_ISO" -V AUTOUNATTEND -graft-points Autounattend.xml="$UNATTEND_XML"
+
+virt-install \
+  --name "$VM_NAME" \
+  --memory {memory_mb} \
+  --vcpus {vcpus} \
+  --disk path="$DISK_IMAGE",format=qcow2,bus=sata \
+  --disk path="$UNATTEND_ISO",device=cdrom \
+  --cdrom "$ISO_PATH" \
+  --os-variant win2k22 \
+  --network network=default,model=e1000 \
+  --graphics spice \
+  --boot uefi \
+  --noautoconsole \
+  --wait 0
+"""
+    return textwrap.dedent(script).strip()
+
+
+_DEPLOYMENT_PROFILES: Dict[str, VMDeploymentProfile] = {
+    "ubuntu-24-04": VMDeploymentProfile(
+        id="ubuntu-24-04",
+        name="Ubuntu Server 24.04 LTS",
+        description="Deploys the official Ubuntu 24.04 LTS cloud image with a ready-to-use automation account.",
+        default_username="playradmin",
+        default_password="PlayrServers!23",
+        default_memory_mb=4096,
+        default_vcpus=2,
+        default_disk_gb=40,
+        download_url="https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img",
+        source_url="https://ubuntu.com/download/server",
+        os_variant="ubuntu24.04",
+        notes="Uses cloud-init to provision the default administrator account and password.",
+        timeout_seconds=900,
+        _builder=_render_ubuntu_deployment_script,
+    ),
+    "windows-server-2022": VMDeploymentProfile(
+        id="windows-server-2022",
+        name="Windows Server 2022 Datacenter (Evaluation)",
+        description="Downloads the Microsoft evaluation ISO and performs an unattended installation with administrator credentials configured.",
+        default_username="playradmin",
+        default_password="PlayrServers!23",
+        default_memory_mb=8192,
+        default_vcpus=4,
+        default_disk_gb=80,
+        download_url="https://software-download.microsoft.com/download/pr/20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+        source_url="https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022",
+        os_variant="win2k22",
+        notes="Creates an Autounattend ISO on the hypervisor to automate the installation and set the administrator password.",
+        timeout_seconds=1800,
+        _builder=_render_windows_deployment_script,
+    ),
+}
+
+
+def get_vm_deployment_profiles() -> Sequence[VMDeploymentProfile]:
+    return list(_DEPLOYMENT_PROFILES.values())
+
+
+def get_vm_deployment_profile(profile_id: str) -> VMDeploymentProfile | None:
+    return _DEPLOYMENT_PROFILES.get(profile_id)
 
 
 class QEMUManager:
@@ -63,6 +415,47 @@ class QEMUManager:
     def get_vm_info(self, name: str) -> CommandResult:
         return self._execute(["virsh", "dominfo", name], f"retrieve information for virtual machine '{name}'")
 
+    def deploy_vm(
+        self,
+        profile_id: str,
+        vm_name: str,
+        *,
+        memory_mb: int | None = None,
+        vcpus: int | None = None,
+        disk_gb: int | None = None,
+    ) -> CommandResult:
+        profile = get_vm_deployment_profile(profile_id)
+        if profile is None:
+            raise ValueError("Unknown deployment profile requested.")
+
+        cleaned_name = _sanitize_vm_name(vm_name)
+
+        def _coerce(value: int | None, default: int, label: str) -> int:
+            try:
+                coerced = int(value) if value is not None else int(default)
+            except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                raise ValueError(f"{label} must be a whole number.") from exc
+            if coerced <= 0:
+                raise ValueError(f"{label} must be greater than zero.")
+            return coerced
+
+        resolved_memory = _coerce(memory_mb, profile.default_memory_mb, "Memory (MiB)")
+        resolved_vcpus = _coerce(vcpus, profile.default_vcpus, "vCPU count")
+        resolved_disk = _coerce(disk_gb, profile.default_disk_gb, "Disk size (GiB)")
+
+        script = profile.build_script(cleaned_name, resolved_memory, resolved_vcpus, resolved_disk)
+
+        try:
+            result = self._runner.run(["bash", "-lc", script], timeout=profile.timeout_seconds)
+        except SSHError as exc:
+            raise QEMUError(f"Failed to deploy virtual machine '{cleaned_name}': {exc}") from exc
+        if result.exit_status != 0:
+            raise QEMUError(
+                f"Failed to deploy virtual machine '{cleaned_name}'",
+                result,
+            )
+        return result
+
     def _execute(self, command: List[str], action: str) -> CommandResult:
         try:
             result = self._runner.run(command)
@@ -74,4 +467,11 @@ class QEMUManager:
         return result
 
 
-__all__ = ["QEMUManager", "QEMUError", "VMInfo"]
+__all__ = [
+    "QEMUManager",
+    "QEMUError",
+    "VMInfo",
+    "VMDeploymentProfile",
+    "get_vm_deployment_profiles",
+    "get_vm_deployment_profile",
+]

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -126,7 +126,20 @@
             color: var(--text);
             font-size: 1rem;
         }
+        .field select {
+            padding: 0.85rem 1rem;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            background: rgba(15, 23, 42, 0.35);
+            color: var(--text);
+            font-size: 1rem;
+        }
         .field input:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+        }
+        .field select:focus {
             outline: none;
             border-color: var(--accent);
             box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
@@ -291,6 +304,12 @@
         tbody tr:hover {
             background: rgba(148, 163, 184, 0.08);
         }
+        tbody tr.selected {
+            background: rgba(56, 189, 248, 0.18);
+        }
+        tbody tr.selected:hover {
+            background: rgba(56, 189, 248, 0.22);
+        }
         .vm-actions {
             display: flex;
             gap: 0.5rem;
@@ -390,6 +409,50 @@
             display: grid;
             gap: 1.5rem;
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+        .deployment-form {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+        }
+        .deployment-grid {
+            display: grid;
+            gap: 1rem;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        }
+        .deployment-credentials {
+            display: grid;
+            gap: 1.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+        dl.credential-list {
+            margin: 0;
+        }
+        dl.credential-list > div {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.75rem;
+            margin-bottom: 0.35rem;
+        }
+        dl.credential-list dt {
+            color: var(--muted);
+            font-weight: 500;
+        }
+        dl.credential-list dd {
+            margin: 0;
+        }
+        .deployment-actions {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+        kbd {
+            background: rgba(148, 163, 184, 0.2);
+            border-radius: 6px;
+            padding: 0.1rem 0.4rem;
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            font-size: 0.75rem;
         }
         dl.stat-list {
             margin: 0;

--- a/app/templates/management.html
+++ b/app/templates/management.html
@@ -113,6 +113,100 @@
 
     <div class="card">
         <div class="section-header">
+            <h2>Deploy a virtual machine</h2>
+            <span class="badge" id="deployment-selected-agent">{% if selected_agent %}{{ selected_agent.name }}{% else %}No agent selected{% endif %}</span>
+        </div>
+        <div id="deployment-placeholder" class="placeholder-box"{% if selected_agent %} style="display: none;"{% endif %}>
+            {% if not agents %}
+                Register a hypervisor to enable guided VM deployments.
+            {% elif not selected_agent %}
+                Select a hypervisor to prepare an automated operating system installation.
+            {% endif %}
+        </div>
+        <div id="deployment-section"{% if not selected_agent %} style="display: none;"{% endif %}>
+            <form id="deployment-form" class="deployment-form">
+                <div class="field">
+                    <label for="deployment-profile">Operating system</label>
+                    <select id="deployment-profile" name="profile_id"></select>
+                    <p class="help-text" id="deployment-description"></p>
+                    <p class="help-text">Source: <a id="deployment-source" href="#" target="_blank" rel="noopener">View documentation</a></p>
+                </div>
+                <div class="deployment-grid">
+                    <div class="field">
+                        <label for="deployment-name">VM name</label>
+                        <input type="text" id="deployment-name" name="vm_name" required placeholder="vm-example">
+                    </div>
+                    <div class="field">
+                        <label for="deployment-memory">Memory (MiB)</label>
+                        <input type="number" id="deployment-memory" name="memory_mb" min="512" step="256" required>
+                    </div>
+                    <div class="field">
+                        <label for="deployment-vcpus">vCPUs</label>
+                        <input type="number" id="deployment-vcpus" name="vcpus" min="1" step="1" required>
+                    </div>
+                    <div class="field">
+                        <label for="deployment-disk">Disk size (GiB)</label>
+                        <input type="number" id="deployment-disk" name="disk_gb" min="10" step="1" required>
+                    </div>
+                </div>
+                <div class="deployment-credentials">
+                    <div>
+                        <h3>Default credentials</h3>
+                        <dl class="credential-list">
+                            <div><dt>Username</dt><dd id="deployment-username">—</dd></div>
+                            <div><dt>Password</dt><dd id="deployment-password">—</dd></div>
+                        </dl>
+                        <p class="help-text" id="deployment-notes"></p>
+                    </div>
+                    <div>
+                        <h3>Download details</h3>
+                        <dl class="credential-list">
+                            <div><dt>Download</dt><dd><a id="deployment-download" href="#" target="_blank" rel="noopener">Open image</a></dd></div>
+                            <div><dt>OS variant</dt><dd id="deployment-variant">—</dd></div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="deployment-actions">
+                    <button type="submit" class="button">Start deployment</button>
+                    <span id="deployment-status" class="ssh-status">Select an operating system to continue.</span>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="section-header">
+            <h2>Virtual console</h2>
+            <span class="badge" id="vm-console-label">{% if selected_agent %}No VM selected{% else %}Unavailable{% endif %}</span>
+        </div>
+        <div id="vm-console-placeholder" class="placeholder-box">
+            {% if not agents %}
+                Register a hypervisor to access guest consoles.
+            {% elif not selected_agent %}
+                Select a hypervisor and choose a VM to open its console.
+            {% else %}
+                Select a virtual machine from the inventory to open its console.
+            {% endif %}
+        </div>
+        <div id="vm-console-section"{% if not selected_agent %} style="display: none;"{% endif %}>
+            <p class="muted">Interact with the selected guest through <code>virsh console</code>. Press <kbd>Ctrl</kbd> + <kbd>]</kbd> to release the session.</p>
+            <div class="ssh-terminal-wrapper">
+                <div id="vm-console-terminal" class="ssh-terminal"></div>
+                <div id="vm-console-overlay" class="ssh-terminal-overlay">Select a virtual machine to open its console.</div>
+            </div>
+            <div class="ssh-controls">
+                <div class="ssh-buttons">
+                    <button type="button" id="vm-console-connect" class="button secondary">Connect</button>
+                    <button type="button" id="vm-console-disconnect" class="button secondary" disabled>Disconnect</button>
+                </div>
+                <span id="vm-console-status" class="ssh-status">Disconnected.</span>
+            </div>
+            <p class="help-text">Console sessions stream directly from the hypervisor. Use the disconnect button or press <kbd>Ctrl</kbd> + <kbd>]</kbd> to exit.</p>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="section-header">
             <h2>Host diagnostics</h2>
             <span class="badge" id="host-info-timestamp">{% if selected_agent %}Awaiting data{% else %}Idle{% endif %}</span>
         </div>
@@ -193,13 +287,15 @@
 <script id="agent-data" type="application/json">{{ agents | tojson }}</script>
 <script id="selected-agent" type="application/json">{{ selected_agent | tojson if selected_agent else 'null' }}</script>
 <script id="management-endpoints" type="application/json">{{ endpoints | tojson }}</script>
+<script id="deployment-profiles" type="application/json">{{ deployment_profiles | tojson }}</script>
 <script>
 (() => {
     const agentDataElement = document.getElementById('agent-data');
     const selectedAgentElement = document.getElementById('selected-agent');
     const endpointsElement = document.getElementById('management-endpoints');
+    const deploymentProfilesElement = document.getElementById('deployment-profiles');
 
-    if (!agentDataElement || !selectedAgentElement || !endpointsElement) {
+    if (!agentDataElement || !selectedAgentElement || !endpointsElement || !deploymentProfilesElement) {
         return;
     }
 
@@ -207,6 +303,9 @@
         agents: JSON.parse(agentDataElement.textContent || '[]'),
         selectedAgent: JSON.parse(selectedAgentElement.textContent || 'null'),
         endpoints: JSON.parse(endpointsElement.textContent || '{}'),
+        deploymentProfiles: JSON.parse(deploymentProfilesElement.textContent || '[]'),
+        vms: [],
+        selectedVm: null,
     };
 
     if (!state.endpoints || !state.endpoints.list_vms) {
@@ -242,6 +341,31 @@
     const hostMemoryAvailable = document.getElementById('host-memory-available');
     const hostInfoUpdated = document.getElementById('host-info-updated');
     const hostLoad = document.getElementById('host-load');
+    const deploymentPlaceholder = document.getElementById('deployment-placeholder');
+    const deploymentSection = document.getElementById('deployment-section');
+    const deploymentForm = document.getElementById('deployment-form');
+    const deploymentProfileSelect = document.getElementById('deployment-profile');
+    const deploymentDescription = document.getElementById('deployment-description');
+    const deploymentSourceLink = document.getElementById('deployment-source');
+    const deploymentDownloadLink = document.getElementById('deployment-download');
+    const deploymentUsername = document.getElementById('deployment-username');
+    const deploymentPassword = document.getElementById('deployment-password');
+    const deploymentVariant = document.getElementById('deployment-variant');
+    const deploymentNotes = document.getElementById('deployment-notes');
+    const deploymentStatus = document.getElementById('deployment-status');
+    const deploymentNameInput = document.getElementById('deployment-name');
+    const deploymentMemoryInput = document.getElementById('deployment-memory');
+    const deploymentVcpusInput = document.getElementById('deployment-vcpus');
+    const deploymentDiskInput = document.getElementById('deployment-disk');
+    const deploymentAgentBadge = document.getElementById('deployment-selected-agent');
+    const vmConsoleLabel = document.getElementById('vm-console-label');
+    const vmConsolePlaceholder = document.getElementById('vm-console-placeholder');
+    const vmConsoleSection = document.getElementById('vm-console-section');
+    const vmConsoleTerminalContainer = document.getElementById('vm-console-terminal');
+    const vmConsoleOverlay = document.getElementById('vm-console-overlay');
+    const vmConsoleConnectButton = document.getElementById('vm-console-connect');
+    const vmConsoleDisconnectButton = document.getElementById('vm-console-disconnect');
+    const vmConsoleStatus = document.getElementById('vm-console-status');
 
     let hostInfoTimer = null;
     let terminal = null;
@@ -249,6 +373,12 @@
     let terminalSocket = null;
     let terminalAgentId = null;
     let closingTerminalState = null;
+    let deploymentProfilesInitialised = false;
+    let currentDeploymentProfileId = null;
+    let vmConsoleTerminal = null;
+    let vmConsoleFitAddon = null;
+    let vmConsoleSocket = null;
+    let vmConsoleClosingState = null;
     const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
     const textDecoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
     const sshCopyButtonLabel = sshCopyButton ? sshCopyButton.textContent : '';
@@ -264,11 +394,14 @@
         return url;
     }
 
-    function buildWebsocketUrl(template, agentId) {
+    function buildWebsocketUrl(template, agentId, vmName) {
         if (!template) {
             return null;
         }
-        const replaced = template.replace('/0/', '/' + agentId + '/');
+        let replaced = template.replace('/0/', '/' + agentId + '/');
+        if (vmName !== undefined) {
+            replaced = replaced.replace('__VM__', encodeURIComponent(vmName));
+        }
         try {
             const url = new URL(replaced, window.location.href);
             url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -301,6 +434,161 @@
         } else {
             sshStatus.classList.remove('error');
         }
+    }
+
+    function setDeploymentStatus(message, isError = false) {
+        if (!deploymentStatus) {
+            return;
+        }
+        deploymentStatus.textContent = message;
+        deploymentStatus.classList.toggle('error', Boolean(isError));
+    }
+
+    function findDeploymentProfile(profileId) {
+        if (!Array.isArray(state.deploymentProfiles)) {
+            return null;
+        }
+        return state.deploymentProfiles.find((profile) => profile && profile.id === profileId) || null;
+    }
+
+    function populateDeploymentProfiles() {
+        if (!deploymentProfileSelect || deploymentProfilesInitialised) {
+            return;
+        }
+        const profiles = Array.isArray(state.deploymentProfiles) ? state.deploymentProfiles : [];
+        deploymentProfileSelect.innerHTML = '';
+        const fragment = document.createDocumentFragment();
+        profiles.forEach((profile) => {
+            if (!profile || !profile.id) {
+                return;
+            }
+            const option = document.createElement('option');
+            option.value = profile.id;
+            option.textContent = profile.name || profile.id;
+            fragment.appendChild(option);
+        });
+        deploymentProfileSelect.appendChild(fragment);
+        deploymentProfilesInitialised = true;
+        if (profiles.length && !currentDeploymentProfileId) {
+            currentDeploymentProfileId = profiles[0].id;
+        }
+    }
+
+    function updateDeploymentProfileDetails(profile, options = {}) {
+        const { resetValues = false } = options;
+
+        if (!profile) {
+            currentDeploymentProfileId = null;
+            if (deploymentDescription) {
+                deploymentDescription.textContent = 'No deployment profiles available.';
+            }
+            if (deploymentSourceLink) {
+                deploymentSourceLink.removeAttribute('href');
+                deploymentSourceLink.textContent = 'Not available';
+            }
+            if (deploymentDownloadLink) {
+                deploymentDownloadLink.removeAttribute('href');
+                deploymentDownloadLink.textContent = 'Unavailable';
+            }
+            if (deploymentUsername) {
+                deploymentUsername.textContent = '—';
+            }
+            if (deploymentPassword) {
+                deploymentPassword.textContent = '—';
+            }
+            if (deploymentVariant) {
+                deploymentVariant.textContent = '—';
+            }
+            if (deploymentNotes) {
+                deploymentNotes.textContent = '';
+            }
+            return;
+        }
+
+        currentDeploymentProfileId = profile.id;
+        if (deploymentProfileSelect && deploymentProfileSelect.value !== profile.id) {
+            deploymentProfileSelect.value = profile.id;
+        }
+        if (deploymentDescription) {
+            deploymentDescription.textContent = profile.description || '';
+        }
+        if (deploymentSourceLink) {
+            if (profile.source_url) {
+                deploymentSourceLink.href = profile.source_url;
+                deploymentSourceLink.textContent = 'View documentation';
+            } else {
+                deploymentSourceLink.removeAttribute('href');
+                deploymentSourceLink.textContent = 'Not available';
+            }
+        }
+        if (deploymentDownloadLink) {
+            if (profile.download_url) {
+                deploymentDownloadLink.href = profile.download_url;
+                deploymentDownloadLink.textContent = 'Open image';
+            } else {
+                deploymentDownloadLink.removeAttribute('href');
+                deploymentDownloadLink.textContent = 'Unavailable';
+            }
+        }
+        if (deploymentUsername) {
+            deploymentUsername.textContent = profile.default_username || '—';
+        }
+        if (deploymentPassword) {
+            deploymentPassword.textContent = profile.default_password || '—';
+        }
+        if (deploymentVariant) {
+            deploymentVariant.textContent = profile.os_variant || '—';
+        }
+        if (deploymentNotes) {
+            deploymentNotes.textContent = profile.notes || '';
+        }
+        if (resetValues) {
+            if (deploymentMemoryInput) {
+                deploymentMemoryInput.value = profile.default_memory_mb || '';
+            }
+            if (deploymentVcpusInput) {
+                deploymentVcpusInput.value = profile.default_vcpus || '';
+            }
+            if (deploymentDiskInput) {
+                deploymentDiskInput.value = profile.default_disk_gb || '';
+            }
+        }
+    }
+
+    function updateDeploymentSection(agent) {
+        if (!deploymentPlaceholder || !deploymentSection) {
+            return;
+        }
+
+        if (deploymentAgentBadge) {
+            deploymentAgentBadge.textContent = agent ? agent.name : 'No agent selected';
+        }
+
+        if (!Array.isArray(state.deploymentProfiles) || !state.deploymentProfiles.length) {
+            deploymentPlaceholder.style.display = '';
+            deploymentPlaceholder.textContent = 'No deployment profiles are available for this environment.';
+            deploymentSection.style.display = 'none';
+            setDeploymentStatus('No deployment profiles available.', true);
+            return;
+        }
+
+        populateDeploymentProfiles();
+
+        if (!agent) {
+            deploymentSection.style.display = 'none';
+            deploymentPlaceholder.style.display = '';
+            deploymentPlaceholder.textContent = state.agents.length
+                ? 'Select a hypervisor to prepare an automated operating system installation.'
+                : 'Register a hypervisor to enable guided VM deployments.';
+            setDeploymentStatus('Select a hypervisor to deploy.', false);
+            return;
+        }
+
+        deploymentPlaceholder.style.display = 'none';
+        deploymentSection.style.display = '';
+        const profile = findDeploymentProfile(currentDeploymentProfileId) || state.deploymentProfiles[0] || null;
+        updateDeploymentProfileDetails(profile, { resetValues: true });
+        setDeploymentStatus('Ready to deploy.', false);
     }
 
     function ensureTerminal() {
@@ -548,6 +836,341 @@
         });
     }
 
+    function ensureVmTerminal() {
+        if (vmConsoleTerminal || !vmConsoleTerminalContainer) {
+            return;
+        }
+        if (typeof window.Terminal !== 'function') {
+            showVmConsoleOverlay('Terminal library failed to load.');
+            setVmConsoleStatus('Browser console unavailable.', true);
+            return;
+        }
+        vmConsoleTerminal = new window.Terminal({
+            convertEol: true,
+            cursorBlink: true,
+            fontFamily: 'JetBrains Mono, SFMono-Regular, Menlo, Consolas, "Liberation Mono", Courier, monospace',
+            fontSize: 14,
+            theme: {
+                background: '#0f172a',
+                foreground: '#f8fafc',
+            },
+        });
+        if (window.FitAddon && typeof window.FitAddon.FitAddon === 'function') {
+            vmConsoleFitAddon = new window.FitAddon.FitAddon();
+            vmConsoleTerminal.loadAddon(vmConsoleFitAddon);
+        }
+        vmConsoleTerminal.open(vmConsoleTerminalContainer);
+        if (vmConsoleFitAddon) {
+            vmConsoleFitAddon.fit();
+        }
+        vmConsoleTerminal.focus();
+        vmConsoleTerminal.onData((data) => {
+            if (vmConsoleSocket && vmConsoleSocket.readyState === WebSocket.OPEN) {
+                if (textEncoder) {
+                    vmConsoleSocket.send(textEncoder.encode(data));
+                } else {
+                    vmConsoleSocket.send(data);
+                }
+            }
+        });
+    }
+
+    function clearVmTerminal() {
+        if (vmConsoleTerminal) {
+            vmConsoleTerminal.reset();
+        }
+    }
+
+    function showVmConsoleOverlay(message) {
+        if (vmConsoleOverlay) {
+            vmConsoleOverlay.textContent = message;
+            vmConsoleOverlay.style.display = 'flex';
+        }
+    }
+
+    function hideVmConsoleOverlay() {
+        if (vmConsoleOverlay) {
+            vmConsoleOverlay.style.display = 'none';
+        }
+    }
+
+    function setVmConsoleStatus(message, isError = false) {
+        if (!vmConsoleStatus) {
+            return;
+        }
+        vmConsoleStatus.textContent = message;
+        if (isError) {
+            vmConsoleStatus.classList.add('error');
+        } else {
+            vmConsoleStatus.classList.remove('error');
+        }
+    }
+
+    function sendVmConsoleResize() {
+        if (!vmConsoleTerminal || !vmConsoleSocket || vmConsoleSocket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+        const payload = {
+            type: 'resize',
+            cols: vmConsoleTerminal.cols,
+            rows: vmConsoleTerminal.rows,
+        };
+        try {
+            vmConsoleSocket.send(JSON.stringify(payload));
+        } catch (_) {
+            // ignore transmission errors
+        }
+    }
+
+    function disconnectVmConsole(showMessage = true) {
+        if (!vmConsoleSocket) {
+            if (showMessage) {
+                setVmConsoleStatus('Disconnected.');
+                showVmConsoleOverlay('Console disconnected.');
+            }
+            if (vmConsoleDisconnectButton) {
+                vmConsoleDisconnectButton.setAttribute('disabled', 'true');
+            }
+            if (vmConsoleConnectButton) {
+                if (state.selectedAgent && state.selectedVm) {
+                    vmConsoleConnectButton.removeAttribute('disabled');
+                } else {
+                    vmConsoleConnectButton.setAttribute('disabled', 'true');
+                }
+            }
+            vmConsoleClosingState = null;
+            return;
+        }
+        vmConsoleClosingState = showMessage ? 'manual' : 'silent';
+        const socket = vmConsoleSocket;
+        vmConsoleSocket = null;
+        try {
+            if (socket.readyState === WebSocket.OPEN) {
+                socket.send(JSON.stringify({ type: 'close' }));
+            }
+            socket.close();
+        } catch (_) {
+            // ignore close failures
+        }
+    }
+
+    function connectVmConsole() {
+        const agent = state.selectedAgent;
+        const vm = state.selectedVm;
+        if (!agent || !vm) {
+            return;
+        }
+
+        ensureVmTerminal();
+        if (!vmConsoleTerminal) {
+            setVmConsoleStatus('Browser console unavailable.', true);
+            showVmConsoleOverlay('Unable to initialize console component.');
+            return;
+        }
+
+        if (!state.endpoints || !state.endpoints.vm_console) {
+            setVmConsoleStatus('Console endpoint is not configured.', true);
+            showVmConsoleOverlay('Console endpoint is not available.');
+            return;
+        }
+
+        const websocketUrl = buildWebsocketUrl(state.endpoints.vm_console, agent.id, vm.name);
+        if (!websocketUrl) {
+            setVmConsoleStatus('Console endpoint is not configured.', true);
+            showVmConsoleOverlay('Console endpoint is not available.');
+            return;
+        }
+
+        if (vmConsoleSocket) {
+            if (
+                vmConsoleSocket.readyState === WebSocket.OPEN &&
+                vmConsoleClosingState === null &&
+                state.selectedVm &&
+                state.selectedVm.name === vm.name
+            ) {
+                return;
+            }
+            disconnectVmConsole(false);
+        }
+
+        vmConsoleClosingState = null;
+        setVmConsoleStatus(`Connecting to ${vm.name}…`);
+        showVmConsoleOverlay(`Connecting to ${vm.name}…`);
+        if (vmConsoleConnectButton) {
+            vmConsoleConnectButton.setAttribute('disabled', 'true');
+        }
+        if (vmConsoleDisconnectButton) {
+            vmConsoleDisconnectButton.removeAttribute('disabled');
+        }
+
+        clearVmTerminal();
+
+        try {
+            vmConsoleSocket = new WebSocket(websocketUrl);
+        } catch (_) {
+            vmConsoleSocket = null;
+            setVmConsoleStatus('Failed to connect.', true);
+            showVmConsoleOverlay('Failed to establish console session.');
+            if (vmConsoleConnectButton) {
+                vmConsoleConnectButton.removeAttribute('disabled');
+            }
+            if (vmConsoleDisconnectButton) {
+                vmConsoleDisconnectButton.setAttribute('disabled', 'true');
+            }
+            return;
+        }
+
+        vmConsoleSocket.binaryType = 'arraybuffer';
+
+        vmConsoleSocket.addEventListener('open', () => {
+            setVmConsoleStatus(`Connected to ${vm.name}`);
+            hideVmConsoleOverlay();
+            if (vmConsoleFitAddon) {
+                vmConsoleFitAddon.fit();
+            }
+            sendVmConsoleResize();
+        });
+
+        vmConsoleSocket.addEventListener('message', (event) => {
+            if (typeof event.data === 'string') {
+                try {
+                    const payload = JSON.parse(event.data);
+                    if (payload.type === 'status' && payload.status === 'connected') {
+                        hideVmConsoleOverlay();
+                        return;
+                    }
+                    if (payload.type === 'error') {
+                        setVmConsoleStatus(payload.message || 'Console session error.', true);
+                        showVmConsoleOverlay(payload.message || 'Console session error.');
+                    }
+                } catch (_) {
+                    // ignore non-JSON control messages
+                }
+                return;
+            }
+
+            if (event.data instanceof ArrayBuffer && vmConsoleTerminal) {
+                let text = '';
+                if (textDecoder) {
+                    text = textDecoder.decode(event.data);
+                } else {
+                    const view = new Uint8Array(event.data);
+                    text = Array.from(view).map((code) => String.fromCharCode(code)).join('');
+                }
+                vmConsoleTerminal.write(text);
+            }
+        });
+
+        vmConsoleSocket.addEventListener('close', () => {
+            const mode = vmConsoleClosingState;
+            vmConsoleClosingState = null;
+            vmConsoleSocket = null;
+            if (vmConsoleDisconnectButton) {
+                vmConsoleDisconnectButton.setAttribute('disabled', 'true');
+            }
+            if (vmConsoleConnectButton) {
+                if (state.selectedAgent && state.selectedVm) {
+                    vmConsoleConnectButton.removeAttribute('disabled');
+                } else {
+                    vmConsoleConnectButton.setAttribute('disabled', 'true');
+                }
+            }
+            if (mode !== 'silent') {
+                setVmConsoleStatus('Disconnected.');
+                showVmConsoleOverlay('Console disconnected.');
+            }
+        });
+
+        vmConsoleSocket.addEventListener('error', () => {
+            setVmConsoleStatus('Failed to connect.', true);
+            showVmConsoleOverlay('Failed to establish console session.');
+        });
+    }
+
+    function selectVm(vm) {
+        if (!vm) {
+            if (state.selectedVm) {
+                state.selectedVm = null;
+                updateVmConsoleSection();
+                renderVmTable();
+            }
+            return;
+        }
+        state.selectedVm = { ...vm };
+        renderVmTable();
+        updateVmConsoleSection();
+    }
+
+    function updateVmConsoleSection() {
+        if (!vmConsolePlaceholder || !vmConsoleSection) {
+            return;
+        }
+        const agent = state.selectedAgent;
+        const vm = state.selectedVm;
+
+        if (!agent) {
+            vmConsolePlaceholder.style.display = '';
+            vmConsolePlaceholder.textContent = state.agents.length
+                ? 'Select a hypervisor and choose a VM to open its console.'
+                : 'Register a hypervisor to access guest consoles.';
+            vmConsoleSection.style.display = 'none';
+            disconnectVmConsole(false);
+            if (vmConsoleLabel) {
+                vmConsoleLabel.textContent = 'Unavailable';
+            }
+            return;
+        }
+
+        vmConsoleSection.style.display = '';
+        if (vmConsoleLabel) {
+            vmConsoleLabel.textContent = vm ? vm.name : 'No VM selected';
+        }
+
+        if (!vm) {
+            vmConsolePlaceholder.style.display = '';
+            vmConsolePlaceholder.textContent = 'Select a virtual machine from the inventory to open its console.';
+            showVmConsoleOverlay('Select a virtual machine to connect.');
+            setVmConsoleStatus('Disconnected.');
+            if (vmConsoleConnectButton) {
+                vmConsoleConnectButton.setAttribute('disabled', 'true');
+            }
+            if (vmConsoleDisconnectButton) {
+                vmConsoleDisconnectButton.setAttribute('disabled', 'true');
+            }
+            return;
+        }
+
+        vmConsolePlaceholder.style.display = 'none';
+        const connected = vmConsoleSocket && vmConsoleSocket.readyState === WebSocket.OPEN;
+        if (connected) {
+            hideVmConsoleOverlay();
+            setVmConsoleStatus(`Connected to ${vm.name}`);
+            if (vmConsoleConnectButton) {
+                vmConsoleConnectButton.setAttribute('disabled', 'true');
+            }
+            if (vmConsoleDisconnectButton) {
+                vmConsoleDisconnectButton.removeAttribute('disabled');
+            }
+        } else {
+            showVmConsoleOverlay(`Click Connect to open ${vm.name}.`);
+            setVmConsoleStatus('Ready to connect.');
+            if (vmConsoleConnectButton) {
+                vmConsoleConnectButton.removeAttribute('disabled');
+            }
+            if (vmConsoleDisconnectButton) {
+                vmConsoleDisconnectButton.setAttribute('disabled', 'true');
+            }
+            clearVmTerminal();
+            ensureVmTerminal();
+            if (vmConsoleFitAddon) {
+                requestAnimationFrame(() => {
+                    vmConsoleFitAddon.fit();
+                    sendVmConsoleResize();
+                });
+            }
+        }
+    }
+
     if (sshConnectButton) {
         sshConnectButton.addEventListener('click', () => {
             if (state.selectedAgent) {
@@ -621,15 +1244,122 @@
         });
     }
 
+    if (vmConsoleConnectButton) {
+        vmConsoleConnectButton.addEventListener('click', () => {
+            connectVmConsole();
+        });
+    }
+
+    if (vmConsoleDisconnectButton) {
+        vmConsoleDisconnectButton.addEventListener('click', () => {
+            disconnectVmConsole();
+        });
+    }
+
+    if (deploymentProfileSelect) {
+        deploymentProfileSelect.addEventListener('change', () => {
+            const selectedId = deploymentProfileSelect.value;
+            const profile = findDeploymentProfile(selectedId);
+            if (profile) {
+                updateDeploymentProfileDetails(profile, { resetValues: true });
+                setDeploymentStatus('Ready to deploy.', false);
+            } else {
+                setDeploymentStatus('Select an operating system to deploy.', true);
+            }
+        });
+    }
+
+    if (deploymentForm) {
+        deploymentForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const agent = state.selectedAgent;
+            if (!agent) {
+                setDeploymentStatus('Select a hypervisor before deploying.', true);
+                return;
+            }
+            if (!state.endpoints || !state.endpoints.deploy_vm) {
+                setDeploymentStatus('Deployment endpoint is not configured.', true);
+                return;
+            }
+
+            const profileId = currentDeploymentProfileId || (deploymentProfileSelect ? deploymentProfileSelect.value : null);
+            const profile = findDeploymentProfile(profileId);
+            if (!profileId || !profile) {
+                setDeploymentStatus('Select an operating system to deploy.', true);
+                return;
+            }
+
+            const vmName = deploymentNameInput ? deploymentNameInput.value.trim() : '';
+            if (!vmName) {
+                setDeploymentStatus('Enter a name for the virtual machine.', true);
+                if (deploymentNameInput) {
+                    deploymentNameInput.focus();
+                }
+                return;
+            }
+
+            const payload = {
+                profile_id: profileId,
+                vm_name: vmName,
+                memory_mb: deploymentMemoryInput ? deploymentMemoryInput.value : undefined,
+                vcpus: deploymentVcpusInput ? deploymentVcpusInput.value : undefined,
+                disk_gb: deploymentDiskInput ? deploymentDiskInput.value : undefined,
+            };
+
+            setDeploymentStatus(`Starting deployment on ${agent.name}…`);
+            const submitButton = deploymentForm.querySelector('button[type="submit"]');
+            if (submitButton) {
+                submitButton.setAttribute('disabled', 'true');
+            }
+
+            try {
+                const url = buildUrl(state.endpoints.deploy_vm, agent.id);
+                const response = await fetch(url, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                const result = await response.json();
+                if (!response.ok || result.status !== 'ok') {
+                    const message = (result && result.message) || 'Deployment failed.';
+                    throw new Error(message);
+                }
+                setDeploymentStatus(result.message || `Deployment for '${vmName}' started.`, false);
+                if (result.profile) {
+                    if (deploymentUsername && result.profile.default_username) {
+                        deploymentUsername.textContent = result.profile.default_username;
+                    }
+                    if (deploymentPassword && result.profile.default_password) {
+                        deploymentPassword.textContent = result.profile.default_password;
+                    }
+                }
+                await fetchVms(agent);
+            } catch (error) {
+                const message = (error && error.message) || 'Deployment failed.';
+                setDeploymentStatus(message, true);
+            } finally {
+                if (submitButton) {
+                    submitButton.removeAttribute('disabled');
+                }
+            }
+        });
+    }
+
     window.addEventListener('resize', () => {
         if (fitAddon) {
             fitAddon.fit();
             sendTerminalResize();
         }
+        if (vmConsoleFitAddon) {
+            vmConsoleFitAddon.fit();
+            sendVmConsoleResize();
+        }
     });
 
     window.addEventListener('beforeunload', () => {
         disconnectTerminal(false);
+        disconnectVmConsole(false);
     });
 
     function clearHostInfoTimer() {
@@ -1168,19 +1898,43 @@
         vmStatus.classList.toggle('danger', isError);
     }
 
-    function renderVmTable(vms) {
+    function renderVmTable() {
         if (!vmTableBody || !vmTableWrapper) {
             return;
         }
+
+        const vms = Array.isArray(state.vms) ? state.vms : [];
         vmTableBody.innerHTML = '';
+
         if (!vms.length) {
-            setVmStatus('No virtual machines reported by the selected hypervisor.');
             vmTableWrapper.style.display = 'none';
+            setVmStatus('No virtual machines reported by the selected hypervisor.');
+            state.selectedVm = null;
+            updateVmConsoleSection();
             return;
         }
+
         vmTableWrapper.style.display = '';
+        const selectedVmName = state.selectedVm ? state.selectedVm.name : null;
+        let selectedVmStillPresent = false;
+
         vms.forEach((vm) => {
             const row = document.createElement('tr');
+            row.className = 'vm-row';
+            row.dataset.vmName = vm.name;
+
+            row.addEventListener('click', (event) => {
+                if (event.target && event.target.closest('button')) {
+                    return;
+                }
+                selectVm(vm);
+            });
+
+            if (selectedVmName && vm.name === selectedVmName) {
+                row.classList.add('selected');
+                selectedVmStillPresent = true;
+            }
+
             const nameCell = document.createElement('td');
             nameCell.textContent = vm.name;
             row.appendChild(nameCell);
@@ -1211,7 +1965,10 @@
                 button.type = 'button';
                 button.className = 'button small' + (variant ? ' ' + variant : '');
                 button.textContent = label;
-                button.addEventListener('click', () => triggerVmAction(vm.name, action));
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    triggerVmAction(vm.name, action);
+                });
                 return button;
             };
 
@@ -1219,20 +1976,34 @@
             actionsCell.appendChild(makeActionButton('Shutdown', 'shutdown'));
             actionsCell.appendChild(makeActionButton('Force stop', 'force-stop', 'danger'));
             actionsCell.appendChild(makeActionButton('Reboot', 'reboot'));
-            row.appendChild(actionsCell);
 
+            const consoleButton = document.createElement('button');
+            consoleButton.type = 'button';
+            consoleButton.className = 'button small secondary';
+            consoleButton.textContent = 'Console';
+            consoleButton.addEventListener('click', (event) => {
+                event.stopPropagation();
+                selectVm(vm);
+                connectVmConsole();
+            });
+            actionsCell.appendChild(consoleButton);
+
+            row.appendChild(actionsCell);
             vmTableBody.appendChild(row);
         });
+
+        if (selectedVmName && !selectedVmStillPresent) {
+            state.selectedVm = null;
+            updateVmConsoleSection();
+        }
     }
 
     async function fetchVms(agent) {
         if (!agent) {
-            if (vmTableBody) {
-                vmTableBody.innerHTML = '';
-            }
-            if (vmTableWrapper) {
-                vmTableWrapper.style.display = 'none';
-            }
+            state.vms = [];
+            state.selectedVm = null;
+            renderVmTable();
+            updateVmConsoleSection();
             setVmStatus('Select a hypervisor to load its virtual machines.');
             return;
         }
@@ -1244,14 +2015,17 @@
             if (payload.status !== 'ok') {
                 throw new Error(payload.message || 'Unable to list virtual machines.');
             }
-            renderVmTable(payload.vms || []);
-            if ((payload.vms || []).length) {
-                setVmStatus(`${payload.vms.length} virtual machine(s) reported by ${agent.name}.`);
+            state.vms = Array.isArray(payload.vms) ? payload.vms : [];
+            renderVmTable();
+            updateVmConsoleSection();
+            if (state.vms.length) {
+                setVmStatus(`${state.vms.length} virtual machine(s) reported by ${agent.name}.`);
             }
         } catch (error) {
-            if (vmTableWrapper) {
-                vmTableWrapper.style.display = 'none';
-            }
+            state.vms = [];
+            state.selectedVm = null;
+            renderVmTable();
+            updateVmConsoleSection();
             setVmStatus(error.message || 'Failed to query virtual machines.', true);
         }
     }
@@ -1281,9 +2055,15 @@
 
     function selectAgent(agent) {
         state.selectedAgent = agent;
+        state.selectedVm = null;
+        state.vms = [];
+        disconnectVmConsole(false);
         renderAgents();
         updateAgentLabel(agent);
         updateSshSection(agent);
+        updateDeploymentSection(agent);
+        renderVmTable();
+        updateVmConsoleSection();
         fetchVms(agent);
         fetchHostInfo(agent);
     }
@@ -1291,6 +2071,9 @@
     renderAgents();
     updateAgentLabel(state.selectedAgent);
     updateSshSection(state.selectedAgent);
+    updateDeploymentSection(state.selectedAgent);
+    renderVmTable();
+    updateVmConsoleSection();
     if (state.selectedAgent) {
         fetchVms(state.selectedAgent);
         fetchHostInfo(state.selectedAgent);

--- a/tests/test_management_deploy.py
+++ b/tests/test_management_deploy.py
@@ -1,0 +1,143 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("MANAGEMENT_SESSION_SECRET", "tests-secret-key")
+
+from app.database import Database
+from app.management import create_app
+from app.qemu import QEMUError
+from app.ssh import CommandResult, HostKeyVerificationError
+
+
+EMAIL = "deploy@example.com"
+PASSWORD = "super-secret"
+
+
+class StubManager:
+    def __init__(self, result=None, error=None):
+        self.calls = []
+        self._result = result or CommandResult(command=["bash", "-lc", ""], exit_status=0, stdout="", stderr="")
+        self._error = error
+
+    def deploy_vm(self, profile_id, vm_name, **kwargs):
+        self.calls.append((profile_id, vm_name, kwargs))
+        if self._error:
+            raise self._error
+        return self._result
+
+
+@pytest.fixture
+def app(tmp_path):
+    database = Database(tmp_path / "management.sqlite3")
+    database.initialize()
+    user, _ = database.create_user("Operator", EMAIL, PASSWORD)
+    database.create_agent(
+        user.id,
+        name="hypervisor-01",
+        hostname="hv.internal",
+        port=22,
+        username="qemu",
+        private_key="dummy",
+        private_key_passphrase=None,
+        allow_unknown_hosts=True,
+        known_hosts_path=None,
+    )
+
+    application = create_app(
+        database=database,
+        session_secret="tests-secret",
+        api_base_url="https://example.com",
+    )
+    return application
+
+
+def authenticate(client: TestClient):
+    response = client.post(
+        "/login",
+        data={"email": EMAIL, "password": PASSWORD},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+
+def test_deploy_endpoint_requires_authentication(app):
+    manager = StubManager()
+    app.state.qemu_manager_factory = lambda agent: manager
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/management/agents/1/deployments",
+            json={"profile_id": "ubuntu-24-04", "vm_name": "vm"},
+        )
+        assert response.status_code == 401
+        assert not manager.calls
+
+
+def test_deploy_endpoint_invokes_manager(app):
+    result = CommandResult(command=["bash", "-lc", "echo"], exit_status=0, stdout="ok", stderr="")
+    manager = StubManager(result=result)
+    app.state.qemu_manager_factory = lambda agent: manager
+
+    with TestClient(app) as client:
+        authenticate(client)
+        response = client.post(
+            "/management/agents/1/deployments",
+            json={
+                "profile_id": "ubuntu-24-04",
+                "vm_name": "vm-alpha",
+                "memory_mb": 4096,
+                "vcpus": 2,
+                "disk_gb": 40,
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "ok"
+        assert "credentials" in payload
+        assert payload["credentials"]["username"] == "playradmin"
+        assert manager.calls
+        profile_id, vm_name, kwargs = manager.calls[0]
+        assert profile_id == "ubuntu-24-04"
+        assert vm_name == "vm-alpha"
+        assert kwargs["memory_mb"] == 4096
+
+
+def test_deploy_endpoint_reports_host_key_error(app):
+    manager = StubManager(error=HostKeyVerificationError("hv.internal", port=22))
+    app.state.qemu_manager_factory = lambda agent: manager
+
+    with TestClient(app) as client:
+        authenticate(client)
+        response = client.post(
+            "/management/agents/1/deployments",
+            json={"profile_id": "ubuntu-24-04", "vm_name": "vm-beta"},
+        )
+        assert response.status_code == 502
+        payload = response.json()
+        assert payload["code"] == "host_key_verification_failed"
+
+
+def test_deploy_endpoint_reports_qemu_error(app):
+    error_result = CommandResult(command=["bash", "-lc", "echo"], exit_status=1, stdout="", stderr="failure")
+    manager = StubManager(error=QEMUError("boom", error_result))
+    app.state.qemu_manager_factory = lambda agent: manager
+
+    with TestClient(app) as client:
+        authenticate(client)
+        response = client.post(
+            "/management/agents/1/deployments",
+            json={"profile_id": "ubuntu-24-04", "vm_name": "vm-gamma"},
+        )
+        assert response.status_code == 502
+        payload = response.json()
+        assert payload["status"] == "error"
+        assert "result" in payload

--- a/tests/test_qemu_deployments.py
+++ b/tests/test_qemu_deployments.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.qemu import QEMUManager
+from app.ssh import CommandResult
+
+
+class DummyRunner:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run(self, args, timeout: int = 60) -> CommandResult:
+        self.calls.append((args, timeout))
+        return CommandResult(command=args, exit_status=0, stdout="ok", stderr="")
+
+
+def extract_script(runner: DummyRunner) -> tuple[str, int]:
+    assert runner.calls, "No commands executed"
+    command, timeout = runner.calls[0]
+    assert command[0] == "bash"
+    assert command[1] == "-lc"
+    return command[2], timeout
+
+
+def test_deploy_vm_ubuntu_generates_cloud_init_script():
+    runner = DummyRunner()
+    manager = QEMUManager(runner)
+
+    result = manager.deploy_vm(
+        "ubuntu-24-04",
+        "vm-test",
+        memory_mb=2048,
+        vcpus=2,
+        disk_gb=32,
+    )
+
+    script, timeout = extract_script(runner)
+    assert "cloud-images.ubuntu.com" in script
+    assert "virt-install" in script
+    assert "cloud-config" in script
+    assert "playradmin:PlayrServers!23" in script
+    assert "ubuntu24.04" in script
+    assert timeout == 900
+    assert result.exit_status == 0
+
+
+def test_deploy_vm_windows_generates_unattend_script():
+    runner = DummyRunner()
+    manager = QEMUManager(runner)
+
+    result = manager.deploy_vm(
+        "windows-server-2022",
+        "win-host",
+        memory_mb=4096,
+        vcpus=4,
+        disk_gb=60,
+    )
+
+    script, timeout = extract_script(runner)
+    assert "software-download.microsoft.com" in script
+    assert "Autounattend.xml" in script
+    assert "PlayrServers!23" in script
+    assert "virt-install" in script
+    assert "win2k22" in script
+    assert timeout == 1800
+    assert result.exit_status == 0
+
+
+def test_deploy_vm_rejects_unknown_profile():
+    runner = DummyRunner()
+    manager = QEMUManager(runner)
+
+    with pytest.raises(ValueError):
+        manager.deploy_vm("unknown-profile", "bad-vm")
+
+
+def test_deploy_vm_rejects_invalid_name():
+    runner = DummyRunner()
+    manager = QEMUManager(runner)
+
+    with pytest.raises(ValueError):
+        manager.deploy_vm("ubuntu-24-04", "invalid name")
+


### PR DESCRIPTION
## Summary
- expose QEMU deployment profiles for Ubuntu 24.04 and Windows Server 2022 with a management API endpoint and VM console websocket
- extend the management dashboard with guided deployment forms, credential previews, and an in-browser virsh console
- document the new workflows and add regression tests around deployment orchestration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdbed8552c8331900dac927220310b