### PR TITLE
Fix Ubuntu meta-data script to use actual VM name

### DIFF
--- a/app/qemu.py
+++ b/app/qemu.py
@@ -204,8 +204,8 @@ ssh_pwauth: true
 EOF
 
 cat <<'EOF' > "$META_DATA"
-instance-id: $VM_NAME
-local-hostname: $VM_NAME
+instance-id: {vm_name}
+local-hostname: {vm_name}
 EOF
 
 virt-install \

--- a/tests/test_qemu_deployments.py
+++ b/tests/test_qemu_deployments.py
@@ -46,6 +46,7 @@ def test_deploy_vm_ubuntu_generates_cloud_init_script():
     assert "cloud-config" in script
     assert "playradmin:PlayrServers!23" in script
     assert "ubuntu24.04" in script
+    assert "instance-id: vm-test" in script
     assert timeout == 900
     assert result.exit_status == 0
 


### PR DESCRIPTION
## Summary
- embed the resolved VM name directly in the generated Ubuntu cloud-init meta-data file
- extend the Ubuntu deployment test to verify the instance-id includes the VM name

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce365f42948331a845bd9c4d6da93a