### PR TITLE
Ensure virsh commands connect to system libvirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ environment variables:
 | `MANAGEMENT_AGENT_KNOWN_HOSTS_PATH` | Known hosts file path applied to auto-registered agents       | unset                          |
 | `MANAGEMENT_AGENT_CLOSE_OTHER_SESSIONS` | Whether agents should terminate other SSH sessions          | `true`                         |
 | `MANAGEMENT_QEMU_IMAGE_ROOT`       | Base directory on the hypervisor for downloaded images, seeds, and unattended media (must already be writable by the SSH automation user) | `/var/lib/libvirt/images/playrservers` |
+| `MANAGEMENT_QEMU_LIBVIRT_URI`      | Libvirt connection URI used when issuing `virsh` commands to remote hypervisors | `qemu:///system` |
 
 
 The systemd unit installed by `scripts/install.sh` sources `/etc/manage-playrservers.env`

--- a/app/management.py
+++ b/app/management.py
@@ -23,6 +23,7 @@ from .models import Agent, User
 from .qemu import (
     QEMUError,
     QEMUManager,
+    build_virsh_command,
     get_vm_deployment_profile,
     get_vm_deployment_profiles,
 )
@@ -1204,7 +1205,7 @@ def create_app(
         runner = _build_ssh_runner(agent)
 
         try:
-            nodeinfo_result = runner.run(["virsh", "nodeinfo"])
+            nodeinfo_result = runner.run(build_virsh_command("nodeinfo"))
         except HostKeyVerificationError as exc:
             return JSONResponse(
                 status_code=status.HTTP_502_BAD_GATEWAY,

--- a/tests/test_management_host_info.py
+++ b/tests/test_management_host_info.py
@@ -26,7 +26,7 @@ class FakeRunner:
     def run(self, args, timeout: int = 60) -> CommandResult:
         self.commands.append(list(args))
         joined = " ".join(args)
-        if joined == "virsh nodeinfo":
+        if joined == "virsh --connect qemu:///system nodeinfo":
             stdout = """CPU model: x86_64\nCPU(s): 4\nCPU frequency: 2400 MHz\nMemory size: 16777216 KiB\n"""
             return CommandResult(command=args, exit_status=0, stdout=stdout, stderr="")
         if joined == "uname -sr":
@@ -102,7 +102,7 @@ def test_host_info_endpoint_returns_metrics(tmp_path):
 
     assert payload["collected_at"].endswith("Z")
     assert runner.commands == [
-        ["virsh", "nodeinfo"],
+        ["virsh", "--connect", "qemu:///system", "nodeinfo"],
         ["uname", "-sr"],
         ["cat", "/proc/loadavg"],
         ["free", "-b"],


### PR DESCRIPTION
## Summary
- ensure virsh operations connect to libvirt using a shared virsh command helper and default to `qemu:///system`
- reuse the helper for host diagnostics and document the new `MANAGEMENT_QEMU_LIBVIRT_URI` configuration
- cover the libvirt URI behaviour with unit tests for VM listing, VM actions, and host info responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce710d1c108331aff4010df07acfe0