### PR TITLE
Enhance installer progress display with section detail

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -107,9 +107,32 @@ fi
 COMPLETED_SECTIONS=0
 CURRENT_TITLE=""
 PROGRESS_ACTIVE=0
+MAIN_PROGRESS_LINE=""
+SECTION_PROGRESS_LINE=""
+SECTION_PROGRESS_WIDTH=26
+CURRENT_SECTION_DESCRIPTIONS=()
+CURRENT_SECTION_TOTAL=0
+CURRENT_SECTION_INDEX=0
+
+refresh_progress_display() {
+    printf "\r\033[2K%s" "$MAIN_PROGRESS_LINE"
+    if [[ -n "$SECTION_PROGRESS_LINE" ]]; then
+        printf "\n\033[2K%s" "$SECTION_PROGRESS_LINE"
+        printf "\033[1A\r"
+    else
+        printf "\r"
+    fi
+    PROGRESS_ACTIVE=1
+}
 
 progress_clear() {
-    printf '\r\033[2K'
+    printf "\r\033[2K"
+    if [[ -n "$SECTION_PROGRESS_LINE" ]]; then
+        printf "\n\033[2K"
+        printf "\033[1A\r"
+    else
+        printf "\r"
+    fi
 }
 
 render_progress() {
@@ -144,11 +167,50 @@ render_progress() {
         percent=$(( completed * 100 / total ))
     fi
 
-    progress_clear
-    printf "%s[%s]%s %3d%% (%d/%d) %s%s" \
+    printf -v MAIN_PROGRESS_LINE "%s[%s]%s %3d%% (%d/%d) %s%s" \
         "$CYAN$BOLD" "$bar" "$RESET" \
         "$percent" "$display_index" "$total" "$title" "$RESET"
-    PROGRESS_ACTIVE=1
+}
+
+render_section_progress() {
+    local completed=$1
+    local total=$2
+    local title=$3
+    local width=$SECTION_PROGRESS_WIDTH
+
+    if (( total <= 0 )); then
+        SECTION_PROGRESS_LINE=""
+        return
+    fi
+
+    if (( completed > total )); then
+        completed=$total
+    fi
+
+    local filled=0
+    if (( total > 0 )); then
+        filled=$(( completed * width / total ))
+    fi
+
+    local bar=""
+    for ((i = 0; i < width; i++)); do
+        if (( i < filled )); then
+            bar+="#"
+        elif (( i == filled && completed < total )); then
+            bar+=">"
+        else
+            bar+="-"
+        fi
+    done
+
+    local percent=0
+    if (( total > 0 )); then
+        percent=$(( completed * 100 / total ))
+    fi
+
+    printf -v SECTION_PROGRESS_LINE "    %s[%s]%s %3d%% (%d/%d) %s%s" \
+        "$CYAN" "$bar" "$RESET" \
+        "$percent" "$completed" "$total" "$title" "$RESET"
 }
 
 progress_start() {
@@ -158,16 +220,77 @@ progress_start() {
         display_index=$TOTAL_SECTIONS
     fi
     render_progress "$COMPLETED_SECTIONS" "$display_index" "Installing: $CURRENT_TITLE"
+    SECTION_PROGRESS_LINE=""
+    CURRENT_SECTION_DESCRIPTIONS=()
+    CURRENT_SECTION_TOTAL=0
+    CURRENT_SECTION_INDEX=0
+    refresh_progress_display
 }
 
 progress_complete() {
     COMPLETED_SECTIONS=$((COMPLETED_SECTIONS + 1))
+    local display_index=$COMPLETED_SECTIONS
+    render_progress "$COMPLETED_SECTIONS" "$display_index" "Completed: $CURRENT_TITLE"
+    refresh_progress_display
 }
 
 progress_finish() {
     render_progress "$COMPLETED_SECTIONS" "$TOTAL_SECTIONS" "Installation complete"
-    printf '\n'
+    refresh_progress_display
+    printf "\r\033[2K%s\n" "$MAIN_PROGRESS_LINE"
+    if [[ -n "$SECTION_PROGRESS_LINE" ]]; then
+        printf "\033[2K%s\n" "$SECTION_PROGRESS_LINE"
+    fi
     PROGRESS_ACTIVE=0
+    MAIN_PROGRESS_LINE=""
+    SECTION_PROGRESS_LINE=""
+}
+
+section_define_steps() {
+    CURRENT_SECTION_DESCRIPTIONS=("$@")
+    CURRENT_SECTION_TOTAL=${#CURRENT_SECTION_DESCRIPTIONS[@]}
+    CURRENT_SECTION_INDEX=0
+    if (( CURRENT_SECTION_TOTAL > 0 )); then
+        local message="Pending: ${CURRENT_SECTION_DESCRIPTIONS[0]}"
+        render_section_progress 0 "$CURRENT_SECTION_TOTAL" "$message"
+    else
+        SECTION_PROGRESS_LINE=""
+    fi
+    refresh_progress_display
+}
+
+section_step() {
+    if (( CURRENT_SECTION_TOTAL == 0 )); then
+        "$@"
+        return
+    fi
+    if (( CURRENT_SECTION_INDEX >= CURRENT_SECTION_TOTAL )); then
+        "$@"
+        return
+    fi
+    local desc="${CURRENT_SECTION_DESCRIPTIONS[$CURRENT_SECTION_INDEX]}"
+    render_section_progress "$CURRENT_SECTION_INDEX" "$CURRENT_SECTION_TOTAL" "Processing: $desc"
+    refresh_progress_display
+    "$@"
+    local status="Completed: $desc"
+    CURRENT_SECTION_INDEX=$((CURRENT_SECTION_INDEX + 1))
+    if (( CURRENT_SECTION_INDEX < CURRENT_SECTION_TOTAL )); then
+        status+=" → Next: ${CURRENT_SECTION_DESCRIPTIONS[$CURRENT_SECTION_INDEX]}"
+    fi
+    render_section_progress "$CURRENT_SECTION_INDEX" "$CURRENT_SECTION_TOTAL" "$status"
+    refresh_progress_display
+}
+
+section_progress_finish() {
+    if (( CURRENT_SECTION_TOTAL > 0 )); then
+        render_section_progress "$CURRENT_SECTION_TOTAL" "$CURRENT_SECTION_TOTAL" "Section complete"
+    else
+        SECTION_PROGRESS_LINE=""
+    fi
+    refresh_progress_display
+    CURRENT_SECTION_DESCRIPTIONS=()
+    CURRENT_SECTION_TOTAL=0
+    CURRENT_SECTION_INDEX=0
 }
 
 run_section() {
@@ -175,6 +298,7 @@ run_section() {
     shift
     progress_start "$title"
     "$@"
+    section_progress_finish
     progress_complete
 }
 
@@ -228,36 +352,61 @@ append_log "$(date -Is)"
 prepare_system_packages() {
     append_log "-- Preparing system packages"
     export DEBIAN_FRONTEND=noninteractive
-    run_cmd apt-get update
-    run_cmd apt-get install -y "${APT_PACKAGES[@]}"
+    local steps=(
+        "Update apt package index"
+        "Install packages: ${APT_PACKAGES[*]}"
+    )
+    section_define_steps "${steps[@]}"
+    section_step run_cmd apt-get update
+    section_step run_cmd apt-get install -y "${APT_PACKAGES[@]}"
 }
 
 configure_application_account() {
     append_log "-- Configuring application account"
+    local steps=(
+        "Ensure system user '${APP_USER}' exists"
+        "Create application directory at ${APP_DIR}"
+    )
+    section_define_steps "${steps[@]}"
     if ! id "$APP_USER" &>/dev/null; then
-        run_cmd useradd --system --create-home --home-dir "/var/lib/${SERVICE_NAME}" --shell /usr/sbin/nologin "$APP_USER"
+        section_step run_cmd useradd --system --create-home --home-dir "/var/lib/${SERVICE_NAME}" --shell /usr/sbin/nologin "$APP_USER"
     else
         append_log "System user ${APP_USER} already exists"
+        section_step :
     fi
-    run_cmd mkdir -p "$APP_DIR"
+    section_step run_cmd mkdir -p "$APP_DIR"
 }
 
 deploy_application_code() {
     append_log "-- Deploying application code"
     if [[ -n "$APP_REPO" ]]; then
         if [[ ! -d "$APP_DIR/.git" ]]; then
-            run_cmd git clone --branch "$APP_BRANCH" "$APP_REPO" "$APP_DIR"
+            local steps=(
+                "Clone repository ${APP_REPO} (branch ${APP_BRANCH})"
+            )
+            section_define_steps "${steps[@]}"
+            section_step run_cmd git clone --branch "$APP_BRANCH" "$APP_REPO" "$APP_DIR"
         else
-            run_cmd git -C "$APP_DIR" fetch --all --tags
-            run_cmd git -C "$APP_DIR" checkout "$APP_BRANCH"
-            run_cmd git -C "$APP_DIR" pull --ff-only
+            local steps=(
+                "Fetch updates for ${APP_REPO}"
+                "Check out branch ${APP_BRANCH}"
+                "Update branch ${APP_BRANCH}"
+            )
+            section_define_steps "${steps[@]}"
+            section_step run_cmd git -C "$APP_DIR" fetch --all --tags
+            section_step run_cmd git -C "$APP_DIR" checkout "$APP_BRANCH"
+            section_step run_cmd git -C "$APP_DIR" pull --ff-only
         fi
     else
         if [[ -z "$PROJECT_ROOT" ]]; then
             log_error "Unable to determine project root. Set APP_REPO or run from a repository checkout."
             exit 1
         fi
-        run_cmd rsync -a --delete "$PROJECT_ROOT/" "$APP_DIR/" \
+        local steps=(
+            "Synchronize local project files into ${APP_DIR}"
+        )
+        section_define_steps "${steps[@]}"
+        section_step run_cmd rsync -a --delete "$PROJECT_ROOT/" "$APP_DIR/" \
             --exclude '.git' \
             --exclude '.venv' \
             --exclude '__pycache__' \
@@ -267,14 +416,20 @@ deploy_application_code() {
 
 bootstrap_python_environment() {
     append_log "-- Bootstrapping Python environment"
-    run_cmd chown -R "$APP_USER:$APP_GROUP" "$APP_DIR"
-    run_cmd sudo -u "$APP_USER" "$PYTHON_BIN" -m venv "$APP_DIR/.venv"
-    run_cmd sudo -u "$APP_USER" bash -c "set -euo pipefail; source '$APP_DIR/.venv/bin/activate'; pip install --upgrade pip; pip install -r '$APP_DIR/requirements.txt'"
-    run_cmd install -d -m 750 -o "$APP_USER" -g "$APP_GROUP" "$APP_DIR/data"
+    local steps=(
+        "Set ownership on ${APP_DIR}"
+        "Create Python virtual environment"
+        "Install Python dependencies"
+        "Prepare application data directory"
+    )
+    section_define_steps "${steps[@]}"
+    section_step run_cmd chown -R "$APP_USER:$APP_GROUP" "$APP_DIR"
+    section_step run_cmd sudo -u "$APP_USER" "$PYTHON_BIN" -m venv "$APP_DIR/.venv"
+    section_step run_cmd sudo -u "$APP_USER" bash -c "set -euo pipefail; source '$APP_DIR/.venv/bin/activate'; pip install --upgrade pip; pip install -r '$APP_DIR/requirements.txt'"
+    section_step run_cmd install -d -m 750 -o "$APP_USER" -g "$APP_GROUP" "$APP_DIR/data"
 }
 
-configure_systemd_service() {
-    append_log "-- Writing systemd service unit"
+write_systemd_unit_file() {
     cat <<EOF > "/etc/systemd/system/${SERVICE_NAME}.service"
 [Unit]
 Description=PlayrServers management API
@@ -300,6 +455,15 @@ WantedBy=multi-user.target
 EOF
 }
 
+configure_systemd_service() {
+    append_log "-- Writing systemd service unit"
+    local steps=(
+        "Install systemd unit file for ${SERVICE_NAME}"
+    )
+    section_define_steps "${steps[@]}"
+    section_step write_systemd_unit_file
+}
+
 generate_secret() {
     "$PYTHON_BIN" - <<'PY'
 import secrets
@@ -307,11 +471,8 @@ print(secrets.token_urlsafe(48))
 PY
 }
 
-configure_environment_file() {
-    append_log "-- Configuring environment defaults"
-    if [[ ! -f "$ENV_FILE" ]]; then
-        SESSION_SECRET=$(generate_secret)
-        cat <<EOF > "$ENV_FILE"
+write_environment_defaults() {
+    cat <<EOF > "$ENV_FILE"
 # Environment overrides for the PlayrServers control plane
 # Set MANAGEMENT_DB_PATH if you want to move the SQLite database.
 # Example:
@@ -319,24 +480,34 @@ configure_environment_file() {
 MANAGEMENT_PUBLIC_API_URL=https://${API_DOMAIN}
 MANAGEMENT_SESSION_SECRET=${SESSION_SECRET}
 EOF
-        run_cmd chown "$APP_USER:$APP_GROUP" "$ENV_FILE"
-        run_cmd chmod 640 "$ENV_FILE"
+}
+
+set_environment_file_permissions() {
+    run_cmd chown "$APP_USER:$APP_GROUP" "$ENV_FILE"
+    run_cmd chmod 640 "$ENV_FILE"
+}
+
+ensure_public_api_url() {
+    if ! grep -q '^MANAGEMENT_PUBLIC_API_URL=' "$ENV_FILE"; then
+        append_log "Adding MANAGEMENT_PUBLIC_API_URL to ${ENV_FILE}"
+        echo "MANAGEMENT_PUBLIC_API_URL=https://${API_DOMAIN}" >> "$ENV_FILE"
     else
-        append_log "Environment file ${ENV_FILE} already exists"
-        if ! grep -q '^MANAGEMENT_PUBLIC_API_URL=' "$ENV_FILE"; then
-            echo "MANAGEMENT_PUBLIC_API_URL=https://${API_DOMAIN}" >> "$ENV_FILE"
-        fi
-        if ! grep -q '^MANAGEMENT_SESSION_SECRET=' "$ENV_FILE"; then
-            SESSION_SECRET=$(generate_secret)
-            echo "MANAGEMENT_SESSION_SECRET=${SESSION_SECRET}" >> "$ENV_FILE"
-        fi
+        append_log "MANAGEMENT_PUBLIC_API_URL already set in ${ENV_FILE}"
     fi
 }
 
-start_services() {
-    append_log "-- Starting services"
-    run_cmd systemctl daemon-reload
-    run_cmd systemctl enable --now "$SERVICE_NAME"
+ensure_session_secret() {
+    if ! grep -q '^MANAGEMENT_SESSION_SECRET=' "$ENV_FILE"; then
+        append_log "Adding MANAGEMENT_SESSION_SECRET to ${ENV_FILE}"
+        local secret
+        secret=$(generate_secret)
+        echo "MANAGEMENT_SESSION_SECRET=${secret}" >> "$ENV_FILE"
+    else
+        append_log "MANAGEMENT_SESSION_SECRET already set in ${ENV_FILE}"
+    fi
+}
+
+verify_service_status() {
     if systemctl is-active --quiet "$SERVICE_NAME"; then
         SERVICE_ACTIVE=1
         append_log "Service ${SERVICE_NAME} is active"
@@ -346,10 +517,45 @@ start_services() {
     fi
 }
 
-configure_nginx_site() {
-    append_log "-- Configuring nginx"
-    local NGINX_CONF="/etc/nginx/sites-available/${SERVICE_NAME}.conf"
-    cat <<EOF > "$NGINX_CONF"
+configure_environment_file() {
+    append_log "-- Configuring environment defaults"
+    if [[ ! -f "$ENV_FILE" ]]; then
+        SESSION_SECRET=$(generate_secret)
+        local steps=(
+            "Create environment override file at ${ENV_FILE}"
+            "Set ownership and permissions on ${ENV_FILE}"
+        )
+        section_define_steps "${steps[@]}"
+        section_step write_environment_defaults
+        section_step set_environment_file_permissions
+    else
+        append_log "Environment file ${ENV_FILE} already exists"
+        local steps=(
+            "Ensure MANAGEMENT_PUBLIC_API_URL is defined"
+            "Ensure MANAGEMENT_SESSION_SECRET is defined"
+        )
+        section_define_steps "${steps[@]}"
+        section_step ensure_public_api_url
+        section_step ensure_session_secret
+    fi
+}
+
+start_services() {
+    append_log "-- Starting services"
+    local steps=(
+        "Reload systemd daemon configuration"
+        "Enable and start ${SERVICE_NAME}"
+        "Verify ${SERVICE_NAME} service status"
+    )
+    section_define_steps "${steps[@]}"
+    section_step run_cmd systemctl daemon-reload
+    section_step run_cmd systemctl enable --now "$SERVICE_NAME"
+    section_step verify_service_status
+}
+
+write_nginx_configuration() {
+    local config_path="$1"
+    cat <<EOF > "$config_path"
 server {
     listen 80;
     server_name ${APP_DOMAIN};
@@ -376,12 +582,30 @@ server {
     }
 }
 EOF
-    run_cmd ln -sf "$NGINX_CONF" "/etc/nginx/sites-enabled/${SERVICE_NAME}.conf"
+}
+
+enable_nginx_site() {
+    local config_path="$1"
+    run_cmd ln -sf "$config_path" "/etc/nginx/sites-enabled/${SERVICE_NAME}.conf"
     if [[ -f /etc/nginx/sites-enabled/default ]]; then
         run_cmd rm -f /etc/nginx/sites-enabled/default
     fi
-    run_cmd nginx -t
-    run_cmd systemctl reload nginx
+}
+
+configure_nginx_site() {
+    append_log "-- Configuring nginx"
+    local NGINX_CONF="/etc/nginx/sites-available/${SERVICE_NAME}.conf"
+    local steps=(
+        "Write nginx site configuration to ${NGINX_CONF}"
+        "Enable nginx site ${SERVICE_NAME}"
+        "Validate nginx configuration"
+        "Reload nginx service"
+    )
+    section_define_steps "${steps[@]}"
+    section_step write_nginx_configuration "$NGINX_CONF"
+    section_step enable_nginx_site "$NGINX_CONF"
+    section_step run_cmd nginx -t
+    section_step run_cmd systemctl reload nginx
 }
 
 run_section "Preparing system packages" prepare_system_packages


### PR DESCRIPTION
## Summary
- add a reusable progress display that renders both overall and per-section status lines for the installer
- instrument each installer section with descriptive sub-steps using new helper functions for environment, systemd, and nginx setup

## Testing
- pytest
- bash -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce74043ea083318bb798a1f697b5e8