### PR TITLE
Add deployment activity tracking and VM destroy action

### DIFF
--- a/app/deployments.py
+++ b/app/deployments.py
@@ -1,0 +1,266 @@
+"""In-memory tracking for virtual machine deployment activity."""
+from __future__ import annotations
+
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Literal, Optional, Sequence
+
+from .ssh import CommandResult
+
+
+LogStream = Literal["stdout", "stderr", "info", "error"]
+
+_MAX_MESSAGES_PER_DEPLOYMENT = 2000
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class DeploymentLogEntry:
+    """Represents a single log event for a VM deployment."""
+
+    sequence: int
+    timestamp: datetime
+    stream: LogStream
+    message: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "sequence": self.sequence,
+            "timestamp": self.timestamp.isoformat(),
+            "stream": self.stream,
+            "message": self.message,
+        }
+
+
+@dataclass
+class DeploymentRecord:
+    """Captures deployment metadata and its associated log messages."""
+
+    id: str
+    user_id: int
+    agent_id: int
+    agent_name: str
+    vm_name: str
+    profile_id: str
+    profile_name: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    parameters: Dict[str, object] = field(default_factory=dict)
+    command: Optional[Sequence[str]] = None
+    exit_status: Optional[int] = None
+    error: Optional[str] = None
+    messages: List[DeploymentLogEntry] = field(default_factory=list)
+    _next_sequence: int = 1
+    _stream_buffers: Dict[str, str] = field(default_factory=dict)
+    _max_messages: int = _MAX_MESSAGES_PER_DEPLOYMENT
+
+    def to_summary_dict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "agent_id": self.agent_id,
+            "agent_name": self.agent_name,
+            "vm_name": self.vm_name,
+            "profile_id": self.profile_id,
+            "profile_name": self.profile_name,
+            "status": self.status,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "parameters": dict(self.parameters) if self.parameters else {},
+            "command": list(self.command) if self.command else None,
+            "exit_status": self.exit_status,
+            "error": self.error,
+        }
+
+    def to_detail_dict(self, *, after: Optional[int] = None) -> Dict[str, object]:
+        summary = self.to_summary_dict()
+        if after is None:
+            relevant = self.messages
+        else:
+            relevant = [entry for entry in self.messages if entry.sequence > after]
+        summary["messages"] = [entry.to_dict() for entry in relevant]
+        summary["next_sequence"] = self._next_sequence
+        return summary
+
+    def add_message(self, stream: LogStream, message: str) -> Optional[DeploymentLogEntry]:
+        text = (message or "").strip("\r\n")
+        if not text:
+            return None
+        return self._append_message(stream, text)
+
+    def add_stream_chunk(self, stream: LogStream, chunk: str) -> None:
+        if not chunk:
+            return
+
+        buffer = self._stream_buffers.get(stream, "") + chunk.replace("\r\n", "\n").replace("\r", "\n")
+        lines = buffer.split("\n")
+
+        if buffer.endswith("\n"):
+            self._stream_buffers[stream] = ""
+        else:
+            self._stream_buffers[stream] = lines.pop() if lines else ""
+
+        for line in lines:
+            cleaned = line.rstrip()
+            if cleaned:
+                self._append_message(stream, cleaned)
+
+    def flush_buffers(self) -> None:
+        for stream, pending in list(self._stream_buffers.items()):
+            if pending:
+                self._append_message(stream, pending.rstrip())
+            self._stream_buffers[stream] = ""
+
+    def _append_message(self, stream: LogStream, message: str) -> DeploymentLogEntry:
+        entry = DeploymentLogEntry(
+            sequence=self._next_sequence,
+            timestamp=_utcnow(),
+            stream=stream,
+            message=message,
+        )
+        self._next_sequence += 1
+        self.messages.append(entry)
+        if len(self.messages) > self._max_messages:
+            excess = len(self.messages) - self._max_messages
+            if excess > 0:
+                self.messages = self.messages[excess:]
+        self.updated_at = entry.timestamp
+        return entry
+
+
+class DeploymentLogManager:
+    """Stores deployment activity for presentation in the management UI."""
+
+    def __init__(self, *, max_records: int = 50) -> None:
+        self._records: Dict[str, DeploymentRecord] = {}
+        self._max_records = max_records
+        self._lock = threading.RLock()
+
+    def create(
+        self,
+        *,
+        user_id: int,
+        agent_id: int,
+        agent_name: str,
+        vm_name: str,
+        profile_id: str,
+        profile_name: str,
+        parameters: Optional[Dict[str, object]] = None,
+    ) -> DeploymentRecord:
+        record_id = uuid.uuid4().hex
+        now = _utcnow()
+        record = DeploymentRecord(
+            id=record_id,
+            user_id=user_id,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            vm_name=vm_name,
+            profile_id=profile_id,
+            profile_name=profile_name,
+            status="pending",
+            created_at=now,
+            updated_at=now,
+            parameters=dict(parameters or {}),
+        )
+        with self._lock:
+            self._records[record_id] = record
+            self._prune_locked()
+        return record
+
+    def append_message(self, deployment_id: str, stream: LogStream, message: str) -> None:
+        with self._lock:
+            record = self._records.get(deployment_id)
+            if record is None:
+                return
+            record.add_message(stream, message)
+
+    def append_stream(self, deployment_id: str, stream: LogStream, chunk: str) -> None:
+        with self._lock:
+            record = self._records.get(deployment_id)
+            if record is None:
+                return
+            record.add_stream_chunk(stream, chunk)
+
+    def mark_running(self, deployment_id: str) -> None:
+        with self._lock:
+            record = self._records.get(deployment_id)
+            if record is None:
+                return
+            record.status = "running"
+            record.updated_at = _utcnow()
+
+    def mark_success(self, deployment_id: str, result: CommandResult) -> None:
+        with self._lock:
+            record = self._records.get(deployment_id)
+            if record is None:
+                return
+            record.flush_buffers()
+            record.status = "succeeded"
+            record.exit_status = result.exit_status
+            record.command = list(result.command)
+            record.updated_at = _utcnow()
+            record.add_message(
+                "info",
+                f"Deployment completed successfully (exit status {result.exit_status}).",
+            )
+
+    def mark_failed(
+        self,
+        deployment_id: str,
+        message: str,
+        result: Optional[CommandResult] = None,
+    ) -> None:
+        with self._lock:
+            record = self._records.get(deployment_id)
+            if record is None:
+                return
+            record.flush_buffers()
+            record.status = "failed"
+            record.error = message
+            if result is not None:
+                record.exit_status = result.exit_status
+                record.command = list(result.command)
+            record.updated_at = _utcnow()
+            record.add_message("error", message)
+
+    def list_for_user(self, user_id: int) -> List[Dict[str, object]]:
+        with self._lock:
+            records = [record for record in self._records.values() if record.user_id == user_id]
+            records.sort(key=lambda item: item.created_at, reverse=True)
+            return [record.to_summary_dict() for record in records]
+
+    def get_for_user(
+        self,
+        user_id: int,
+        deployment_id: str,
+        *,
+        after: Optional[int] = None,
+    ) -> Optional[Dict[str, object]]:
+        with self._lock:
+            record = self._records.get(deployment_id)
+            if record is None or record.user_id != user_id:
+                return None
+            return record.to_detail_dict(after=after)
+
+    def _prune_locked(self) -> None:
+        if len(self._records) <= self._max_records:
+            return
+
+        finished = [
+            record
+            for record in self._records.values()
+            if record.status in {"succeeded", "failed"}
+        ]
+        finished.sort(key=lambda record: record.updated_at)
+
+        while len(self._records) > self._max_records and finished:
+            record = finished.pop(0)
+            self._records.pop(record.id, None)
+
+
+__all__ = ["DeploymentLogManager", "DeploymentLogEntry", "DeploymentRecord"]

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -108,6 +108,13 @@
         .button.secondary:hover {
             background: rgba(148, 163, 184, 0.1);
         }
+        .button.danger {
+            background: rgba(248, 113, 113, 0.88);
+            color: #0f172a;
+        }
+        .button.danger:hover {
+            background: rgba(248, 113, 113, 1);
+        }
         .field {
             display: flex;
             flex-direction: column;
@@ -168,6 +175,68 @@
             background: rgba(251, 191, 36, 0.12);
             border-color: rgba(251, 191, 36, 0.35);
             color: #fef08a;
+        }
+        .deployment-activity-list {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+        .deployment-entry {
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 14px;
+            padding: 1.25rem;
+            background: rgba(15, 23, 42, 0.45);
+        }
+        .deployment-entry-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 1rem;
+            margin-bottom: 0.75rem;
+        }
+        .deployment-entry-header h3 {
+            margin: 0;
+            font-size: 1.05rem;
+        }
+        .deployment-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-bottom: 0.75rem;
+            font-size: 0.85rem;
+            color: var(--muted);
+        }
+        .deployment-log-output {
+            background: rgba(15, 23, 42, 0.6);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 12px;
+            padding: 0.75rem 1rem;
+            max-height: 260px;
+            overflow-y: auto;
+            font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 0.85rem;
+            line-height: 1.4;
+        }
+        .deployment-log-line {
+            display: grid;
+            grid-template-columns: 4.25rem 1fr;
+            gap: 0.75rem;
+            padding: 0.2rem 0;
+            word-break: break-word;
+        }
+        .deployment-log-line[data-stream="stderr"] {
+            color: var(--danger);
+        }
+        .deployment-log-line[data-stream="info"] {
+            color: #bae6fd;
+        }
+        .deployment-log-time {
+            color: var(--muted);
+            font-size: 0.75rem;
+        }
+        .deployment-log-empty {
+            color: var(--muted);
+            font-size: 0.9rem;
         }
         pre {
             background: rgba(15, 23, 42, 0.6);
@@ -287,6 +356,10 @@
         .badge.danger {
             background: rgba(248, 113, 113, 0.25);
             color: #fecaca;
+        }
+        .badge.info {
+            background: rgba(56, 189, 248, 0.25);
+            color: #bae6fd;
         }
         .table-wrapper {
             overflow-x: auto;

--- a/app/templates/management.html
+++ b/app/templates/management.html
@@ -181,6 +181,18 @@
 
     <div class="card">
         <div class="section-header">
+            <h2>Deployment activity</h2>
+            <button type="button" id="deployment-refresh" class="button small secondary">Refresh</button>
+        </div>
+        <div id="deployment-activity-error" class="notice danger" style="display: none;"></div>
+        <div id="deployment-activity-empty" class="placeholder-box">
+            No deployments have been started yet. Launch a virtual machine to track its progress here.
+        </div>
+        <div id="deployment-activity" class="deployment-activity-list" style="display: none;"></div>
+    </div>
+
+    <div class="card">
+        <div class="section-header">
             <h2>Virtual console</h2>
             <span class="badge" id="vm-console-label">{% if selected_agent %}No VM selected{% else %}Unavailable{% endif %}</span>
         </div>
@@ -311,6 +323,8 @@
         deploymentProfiles: JSON.parse(deploymentProfilesElement.textContent || '[]'),
         vms: [],
         selectedVm: null,
+        deployments: [],
+        deploymentDetails: {},
     };
 
     if (!state.endpoints || !state.endpoints.list_vms) {
@@ -346,6 +360,10 @@
     const hostMemoryAvailable = document.getElementById('host-memory-available');
     const hostInfoUpdated = document.getElementById('host-info-updated');
     const hostLoad = document.getElementById('host-load');
+    const deploymentActivityContainer = document.getElementById('deployment-activity');
+    const deploymentActivityEmpty = document.getElementById('deployment-activity-empty');
+    const deploymentActivityError = document.getElementById('deployment-activity-error');
+    const deploymentRefreshButton = document.getElementById('deployment-refresh');
     const deploymentPlaceholder = document.getElementById('deployment-placeholder');
     const deploymentSection = document.getElementById('deployment-section');
     const deploymentForm = document.getElementById('deployment-form');
@@ -386,6 +404,9 @@
     let vmConsoleFitAddon = null;
     let vmConsoleSocket = null;
     let vmConsoleClosingState = null;
+    let deploymentSummaryTimer = null;
+    let deploymentSummaryInFlight = false;
+    const deploymentPollTimers = {};
     const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
     const textDecoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
     const sshCopyButtonLabel = sshCopyButton ? sshCopyButton.textContent : '';
@@ -413,6 +434,17 @@
             const url = new URL(replaced, window.location.href);
             url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
             return url.toString();
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function buildDeploymentDetailUrl(template, deploymentId) {
+        if (!template) {
+            return null;
+        }
+        try {
+            return template.replace('__DEPLOYMENT__', encodeURIComponent(deploymentId));
         } catch (_) {
             return null;
         }
@@ -449,6 +481,414 @@
         }
         deploymentStatus.textContent = message;
         deploymentStatus.classList.toggle('error', Boolean(isError));
+    }
+
+    function formatTimestamp(value) {
+        if (!value) {
+            return '—';
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return value;
+        }
+        return date.toLocaleString();
+    }
+
+    function formatLogTime(value) {
+        if (!value) {
+            return '—';
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return value;
+        }
+        return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    }
+
+    function formatDeploymentStatus(status) {
+        const normalized = (status || '').toLowerCase();
+        if (normalized === 'pending') {
+            return 'Pending';
+        }
+        if (normalized === 'running') {
+            return 'Running';
+        }
+        if (normalized === 'succeeded') {
+            return 'Completed';
+        }
+        if (normalized === 'failed') {
+            return 'Failed';
+        }
+        return status || 'Unknown';
+    }
+
+    function statusToBadgeClass(status) {
+        const normalized = (status || '').toLowerCase();
+        if (normalized === 'pending') {
+            return 'warning';
+        }
+        if (normalized === 'running') {
+            return 'info';
+        }
+        if (normalized === 'succeeded') {
+            return 'success';
+        }
+        if (normalized === 'failed') {
+            return 'danger';
+        }
+        return '';
+    }
+
+    function createMetaItem(label, value) {
+        const span = document.createElement('span');
+        const strong = document.createElement('strong');
+        strong.textContent = `${label}:`;
+        span.appendChild(strong);
+        span.append(' ', value ?? '—');
+        return span;
+    }
+
+    function showDeploymentError(message) {
+        if (deploymentActivityError) {
+            deploymentActivityError.textContent = message;
+            deploymentActivityError.style.display = '';
+        }
+    }
+
+    function hideDeploymentError() {
+        if (deploymentActivityError) {
+            deploymentActivityError.textContent = '';
+            deploymentActivityError.style.display = 'none';
+        }
+    }
+
+    function clearDeploymentPoll(id) {
+        const timer = deploymentPollTimers[id];
+        if (timer) {
+            window.clearTimeout(timer);
+            delete deploymentPollTimers[id];
+        }
+    }
+
+    function scheduleDeploymentPoll(id, delay = 2000) {
+        clearDeploymentPoll(id);
+        deploymentPollTimers[id] = window.setTimeout(() => {
+            performDeploymentPoll(id);
+        }, delay);
+    }
+
+    function performDeploymentPoll(id, options = {}) {
+        const detail = state.deploymentDetails[id];
+        if (!detail) {
+            clearDeploymentPoll(id);
+            return;
+        }
+        const fetchOptions = {};
+        if (options.full) {
+            fetchOptions.full = true;
+        } else if (typeof options.after === 'number') {
+            fetchOptions.after = options.after;
+        } else if (typeof detail.lastSequence === 'number' && detail.lastSequence >= 0) {
+            fetchOptions.after = detail.lastSequence;
+        }
+        fetchDeploymentDetail(id, fetchOptions);
+    }
+
+    async function fetchDeploymentDetail(id, options = {}) {
+        const detail = state.deploymentDetails[id];
+        if (!detail || !state.endpoints || !state.endpoints.deployment_detail) {
+            return;
+        }
+        if (detail.loading) {
+            return;
+        }
+
+        detail.loading = true;
+        let url = buildDeploymentDetailUrl(state.endpoints.deployment_detail, id);
+        if (!url) {
+            detail.loading = false;
+            return;
+        }
+
+        const params = new URLSearchParams();
+        if (!options.full) {
+            const afterValue =
+                typeof options.after === 'number'
+                    ? options.after
+                    : typeof detail.lastSequence === 'number' && detail.lastSequence >= 0
+                        ? detail.lastSequence
+                        : null;
+            if (afterValue !== null && afterValue >= 0) {
+                params.set('after', String(afterValue));
+            }
+        }
+
+        const query = params.toString();
+        if (query) {
+            url += (url.includes('?') ? '&' : '?') + query;
+        }
+
+        try {
+            const response = await fetch(url, {
+                credentials: 'same-origin',
+                cache: 'no-store',
+            });
+            const payload = await response.json();
+            if (!response.ok || !payload || payload.status !== 'ok' || !payload.deployment) {
+                throw new Error((payload && payload.message) || 'Failed to load deployment details.');
+            }
+
+            const deployment = payload.deployment;
+            detail.summary = { ...detail.summary, ...deployment };
+
+            const messages = Array.isArray(deployment.messages) ? deployment.messages : [];
+            if (messages.length) {
+                if (!Array.isArray(detail.messages)) {
+                    detail.messages = [];
+                }
+                detail.messages = detail.messages.concat(messages);
+                if (detail.messages.length > 1000) {
+                    detail.messages = detail.messages.slice(-1000);
+                }
+                const lastMessage = messages[messages.length - 1];
+                if (lastMessage && typeof lastMessage.sequence === 'number') {
+                    detail.lastSequence = lastMessage.sequence;
+                }
+            } else if (typeof deployment.next_sequence === 'number') {
+                detail.lastSequence = deployment.next_sequence - 1;
+            }
+
+            const index = state.deployments.findIndex((item) => item && item.id === deployment.id);
+            if (index !== -1) {
+                state.deployments[index] = { ...state.deployments[index], ...deployment };
+            }
+
+            detail.error = null;
+            detail.initialised = true;
+            renderDeploymentActivity();
+
+            if (deployment.status === 'running' || deployment.status === 'pending') {
+                scheduleDeploymentPoll(id);
+            } else {
+                clearDeploymentPoll(id);
+            }
+        } catch (error) {
+            detail.error = error.message || 'Failed to load deployment details.';
+            renderDeploymentActivity();
+            scheduleDeploymentPoll(id, 5000);
+        } finally {
+            detail.loading = false;
+        }
+    }
+
+    function renderDeploymentActivity() {
+        if (!deploymentActivityContainer || !deploymentActivityEmpty) {
+            return;
+        }
+
+        const deployments = Array.isArray(state.deployments) ? state.deployments : [];
+        if (!deployments.length) {
+            deploymentActivityContainer.style.display = 'none';
+            deploymentActivityContainer.innerHTML = '';
+            deploymentActivityEmpty.style.display = '';
+            return;
+        }
+
+        deploymentActivityEmpty.style.display = 'none';
+        deploymentActivityContainer.style.display = '';
+        deploymentActivityContainer.innerHTML = '';
+
+        const fragment = document.createDocumentFragment();
+        deployments.forEach((summary) => {
+            if (!summary || !summary.id) {
+                return;
+            }
+            const detail = state.deploymentDetails[summary.id] || {
+                messages: [],
+                summary,
+            };
+
+            const entry = document.createElement('div');
+            entry.className = 'deployment-entry';
+
+            const header = document.createElement('div');
+            header.className = 'deployment-entry-header';
+            const title = document.createElement('h3');
+            title.textContent = summary.vm_name || summary.id;
+            header.appendChild(title);
+            const badge = document.createElement('span');
+            const badgeClass = statusToBadgeClass(summary.status);
+            badge.className = 'badge' + (badgeClass ? ' ' + badgeClass : '');
+            badge.textContent = formatDeploymentStatus(summary.status);
+            header.appendChild(badge);
+            entry.appendChild(header);
+
+            const meta = document.createElement('div');
+            meta.className = 'deployment-meta';
+            meta.appendChild(createMetaItem('Agent', summary.agent_name || `#${summary.agent_id}`));
+            if (summary.profile_name) {
+                meta.appendChild(createMetaItem('Profile', summary.profile_name));
+            }
+            if (summary.parameters && typeof summary.parameters.memory_mb === 'number') {
+                meta.appendChild(createMetaItem('Memory', `${summary.parameters.memory_mb} MiB`));
+            }
+            if (summary.parameters && typeof summary.parameters.vcpus === 'number') {
+                meta.appendChild(createMetaItem('vCPUs', summary.parameters.vcpus));
+            }
+            if (summary.parameters && typeof summary.parameters.disk_gb === 'number') {
+                meta.appendChild(createMetaItem('Disk', `${summary.parameters.disk_gb} GiB`));
+            }
+            meta.appendChild(createMetaItem('Queued', formatTimestamp(summary.created_at)));
+            meta.appendChild(createMetaItem('Updated', formatTimestamp(summary.updated_at)));
+            if (typeof summary.exit_status === 'number' && summary.status && summary.status.toLowerCase() !== 'running' && summary.status.toLowerCase() !== 'pending') {
+                meta.appendChild(createMetaItem('Exit status', summary.exit_status));
+            }
+            entry.appendChild(meta);
+
+            if (detail && detail.error) {
+                const errorNotice = document.createElement('div');
+                errorNotice.className = 'notice danger';
+                errorNotice.textContent = detail.error;
+                entry.appendChild(errorNotice);
+            }
+
+            const logOutput = document.createElement('div');
+            logOutput.className = 'deployment-log-output';
+            const messages = detail && Array.isArray(detail.messages) ? detail.messages : [];
+            if (messages.length) {
+                messages.forEach((message) => {
+                    if (!message) {
+                        return;
+                    }
+                    const line = document.createElement('div');
+                    line.className = 'deployment-log-line';
+                    if (message.stream) {
+                        line.dataset.stream = message.stream;
+                    }
+                    const timestamp = document.createElement('div');
+                    timestamp.className = 'deployment-log-time';
+                    timestamp.textContent = formatLogTime(message.timestamp);
+                    const text = document.createElement('div');
+                    text.textContent = message.message || '';
+                    line.appendChild(timestamp);
+                    line.appendChild(text);
+                    logOutput.appendChild(line);
+                });
+            } else {
+                const placeholder = document.createElement('div');
+                placeholder.className = 'deployment-log-empty';
+                if (detail && detail.loading) {
+                    placeholder.textContent = 'Loading deployment logs…';
+                } else if (summary.status && summary.status.toLowerCase() === 'failed') {
+                    placeholder.textContent = 'Deployment failed before producing log output.';
+                } else if (summary.status && summary.status.toLowerCase() === 'succeeded') {
+                    placeholder.textContent = 'Deployment completed without log output.';
+                } else {
+                    placeholder.textContent = 'No log output yet.';
+                }
+                logOutput.appendChild(placeholder);
+            }
+            entry.appendChild(logOutput);
+
+            fragment.appendChild(entry);
+        });
+
+        deploymentActivityContainer.appendChild(fragment);
+    }
+
+    function scheduleDeploymentSummaryRefresh(delay = 20000) {
+        if (deploymentSummaryTimer !== null) {
+            window.clearTimeout(deploymentSummaryTimer);
+        }
+        deploymentSummaryTimer = window.setTimeout(() => {
+            refreshDeploymentSummaries();
+        }, delay);
+    }
+
+    async function refreshDeploymentSummaries(options = {}) {
+        if (!state.endpoints || !state.endpoints.deployment_logs) {
+            return;
+        }
+        if (deploymentSummaryInFlight) {
+            return;
+        }
+        deploymentSummaryInFlight = true;
+        if (deploymentSummaryTimer !== null) {
+            window.clearTimeout(deploymentSummaryTimer);
+            deploymentSummaryTimer = null;
+        }
+
+        try {
+            const response = await fetch(state.endpoints.deployment_logs, {
+                credentials: 'same-origin',
+                cache: 'no-store',
+            });
+            const payload = await response.json();
+            if (!response.ok || !payload || payload.status !== 'ok') {
+                throw new Error((payload && payload.message) || 'Failed to load deployments.');
+            }
+
+            const deployments = Array.isArray(payload.deployments) ? payload.deployments.slice() : [];
+            deployments.sort((a, b) => {
+                const aTime = new Date(a && a.created_at ? a.created_at : 0).getTime();
+                const bTime = new Date(b && b.created_at ? b.created_at : 0).getTime();
+                return bTime - aTime;
+            });
+            state.deployments = deployments;
+
+            const seen = new Set();
+            deployments.forEach((summary) => {
+                if (!summary || !summary.id) {
+                    return;
+                }
+                seen.add(summary.id);
+                const detail = state.deploymentDetails[summary.id];
+                if (detail) {
+                    detail.summary = { ...detail.summary, ...summary };
+                } else {
+                    state.deploymentDetails[summary.id] = {
+                        summary: { ...summary },
+                        messages: [],
+                        lastSequence: -1,
+                        error: null,
+                        loading: false,
+                        initialised: false,
+                    };
+                }
+            });
+
+            Object.keys(state.deploymentDetails).forEach((id) => {
+                if (!seen.has(id)) {
+                    clearDeploymentPoll(id);
+                    delete state.deploymentDetails[id];
+                }
+            });
+
+            hideDeploymentError();
+            renderDeploymentActivity();
+
+            deployments.forEach((summary) => {
+                if (!summary || !summary.id) {
+                    return;
+                }
+                const detail = state.deploymentDetails[summary.id];
+                if (!detail) {
+                    return;
+                }
+                if (!detail.initialised) {
+                    detail.initialised = true;
+                    fetchDeploymentDetail(summary.id, { full: true });
+                } else if (summary.status === 'running' || summary.status === 'pending') {
+                    scheduleDeploymentPoll(summary.id);
+                }
+            });
+        } catch (error) {
+            showDeploymentError(error.message || 'Failed to load deployments.');
+            renderDeploymentActivity();
+        } finally {
+            deploymentSummaryInFlight = false;
+            scheduleDeploymentSummaryRefresh(options.manual ? 20000 : 20000);
+        }
     }
 
     function findDeploymentProfile(profileId) {
@@ -1284,6 +1724,12 @@
         });
     }
 
+    if (deploymentRefreshButton) {
+        deploymentRefreshButton.addEventListener('click', () => {
+            refreshDeploymentSummaries({ manual: true });
+        });
+    }
+
     if (deploymentForm) {
         deploymentForm.addEventListener('submit', async (event) => {
             event.preventDefault();
@@ -1343,6 +1789,9 @@
                     throw new Error(message);
                 }
                 setDeploymentStatus(result.message || `Deployment for '${vmName}' started.`, false);
+                if (result.deployment_id) {
+                    refreshDeploymentSummaries({ manual: true });
+                }
                 if (result.credentials) {
                     if (deploymentUsername && result.credentials.username) {
                         deploymentUsername.value = result.credentials.username;
@@ -1388,6 +1837,13 @@
     window.addEventListener('beforeunload', () => {
         disconnectTerminal(false);
         disconnectVmConsole(false);
+        if (deploymentSummaryTimer !== null) {
+            window.clearTimeout(deploymentSummaryTimer);
+            deploymentSummaryTimer = null;
+        }
+        Object.keys(deploymentPollTimers).forEach((id) => {
+            clearDeploymentPoll(id);
+        });
     });
 
     function clearHostInfoTimer() {
@@ -1991,24 +2447,35 @@
             const actionsCell = document.createElement('td');
             actionsCell.className = 'vm-actions';
 
-            const makeActionButton = (label, action, variant) => {
-                const button = document.createElement('button');
-                button.type = 'button';
-                button.className = 'button small' + (variant ? ' ' + variant : '');
-                button.textContent = label;
-                button.addEventListener('click', (event) => {
-                    event.stopPropagation();
-                    triggerVmAction(vm.name, action);
-                });
-                return button;
-            };
+        const makeActionButton = (label, action, variant, options = {}) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'button small' + (variant ? ' ' + variant : '');
+            button.textContent = label;
+            button.addEventListener('click', (event) => {
+                event.stopPropagation();
+                if (options.confirmMessage) {
+                    const confirmed = window.confirm(options.confirmMessage);
+                    if (!confirmed) {
+                        return;
+                    }
+                }
+                triggerVmAction(vm.name, action);
+            });
+            return button;
+        };
 
-            actionsCell.appendChild(makeActionButton('Start', 'start'));
-            actionsCell.appendChild(makeActionButton('Shutdown', 'shutdown'));
-            actionsCell.appendChild(makeActionButton('Force stop', 'force-stop', 'danger'));
-            actionsCell.appendChild(makeActionButton('Reboot', 'reboot'));
+        actionsCell.appendChild(makeActionButton('Start', 'start'));
+        actionsCell.appendChild(makeActionButton('Shutdown', 'shutdown'));
+        actionsCell.appendChild(makeActionButton('Force stop', 'force-stop', 'danger'));
+        actionsCell.appendChild(makeActionButton('Reboot', 'reboot'));
+        actionsCell.appendChild(
+            makeActionButton('Destroy', 'destroy', 'danger', {
+                confirmMessage: `Destroy ${vm.name}? This removes the virtual machine definition and associated storage.`,
+            }),
+        );
 
-            const consoleButton = document.createElement('button');
+        const consoleButton = document.createElement('button');
             consoleButton.type = 'button';
             consoleButton.className = 'button small secondary';
             consoleButton.textContent = 'Console';
@@ -2118,6 +2585,8 @@
         setVmStatus('Register a hypervisor to view its virtual machines.');
         showHostInfoPlaceholder('Register a hypervisor to monitor its performance metrics.');
     }
+
+    refreshDeploymentSummaries({ manual: true });
 })();
 </script>
 {% endblock %}

--- a/tests/test_qemu_deployments.py
+++ b/tests/test_qemu_deployments.py
@@ -237,6 +237,7 @@ def test_vm_actions_use_configured_uri(monkeypatch):
     manager.force_stop_vm("vm-three")
     manager.reboot_vm("vm-four")
     manager.get_vm_info("vm-five")
+    manager.destroy_vm("vm-six")
 
     expected_prefix = ["virsh", "--connect", "qemu+ssh://hv.local/system"]
     commands = [call[0] for call in runner.calls]
@@ -246,4 +247,5 @@ def test_vm_actions_use_configured_uri(monkeypatch):
         expected_prefix + ["destroy", "vm-three"],
         expected_prefix + ["reboot", "vm-four"],
         expected_prefix + ["dominfo", "vm-five"],
+        expected_prefix + ["undefine", "vm-six", "--remove-all-storage", "--nvram"],
     ]


### PR DESCRIPTION
## Summary
- capture streaming stdout/stderr for deployments and track progress in a new DeploymentLogManager
- surface deployment activity in the management API/UI with polling endpoints and refreshed templates
- add a destroy VM action and extend tests to cover streaming logs and cleanup behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce77a124508331a9268bee040e0042