### PR TITLE
Require agent-based hypervisor pairing and secure API key reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,32 +194,14 @@ API does not expose a self-registration endpoint.
 | Method | Path                               | Description                                   |
 | ------ | ---------------------------------- | --------------------------------------------- |
 | GET    | `/agents`                          | List the caller's registered agents           |
-| POST   | `/agents`                          | Register a new agent / virtualization host    |
 | GET    | `/agents/{id}`                     | Retrieve metadata for a specific agent        |
-| PATCH  | `/agents/{id}`                     | Update agent metadata or credentials          |
+| PATCH  | `/agents/{id}`                     | Update agent metadata                         |
 | DELETE | `/agents/{id}`                     | Remove an agent                               |
 
 > **Security note:** SSH private keys uploaded to the control plane are stored
-> encrypted at rest and are never retrievable via the public API. Legacy
-> clients that previously called `/agents/{id}/credentials` now receive a
-> `404 Not Found` response and should instead rely on key material supplied at
-> registration time or the automatic provisioning flow documented below.
-
-Agent registration payload example:
-
-```bash
-curl -X POST https://api.playrservers.com/agents \
-  -H 'Authorization: Bearer <api-key>' \
-  -H 'Content-Type: application/json' \
-  -d '{
-        "name": "dalek-hypervisor",
-        "hostname": "192.0.2.15",
-        "port": 22,
-        "username": "qemu-admin",
-        "private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----\n",
-        "allow_unknown_hosts": false
-      }'
-```
+> encrypted at rest and are never retrievable via the public API. Manual
+> registration with raw credentials (`POST /agents`) has been removed—hosts must
+> pair themselves via the automatic provisioning flow documented below.
 
 ### Agent auto-registration
 

--- a/app/api.py
+++ b/app/api.py
@@ -35,17 +35,6 @@ class RotateAPIKeyResponse(BaseModel):
     api_key_prefix: str
 
 
-class CreateAgentRequest(BaseModel):
-    name: str = Field(..., min_length=1, max_length=100)
-    hostname: str = Field(..., min_length=1, max_length=255)
-    port: int = Field(default=22, ge=1, le=65535)
-    username: str = Field(..., min_length=1, max_length=64)
-    private_key: str = Field(..., min_length=40)
-    private_key_passphrase: Optional[str] = Field(default=None, max_length=255)
-    allow_unknown_hosts: bool = False
-    known_hosts_path: Optional[str] = Field(default=None, max_length=1024)
-
-
 class UpdateAgentRequest(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
     hostname: Optional[str] = Field(default=None, min_length=1, max_length=255)
@@ -280,25 +269,6 @@ def create_app(
     async def list_agents(current_user: User = Depends(get_current_user), db: Database = Depends(get_db)) -> List[AgentResponse]:
         agents = db.list_agents_for_user(current_user.id)
         return [agent_to_response(agent) for agent in agents]
-
-    @protected_router.post("/agents", response_model=AgentResponse, status_code=status.HTTP_201_CREATED)
-    async def create_agent(
-        payload: CreateAgentRequest,
-        current_user: User = Depends(get_current_user),
-        db: Database = Depends(get_db),
-    ) -> AgentResponse:
-        agent = db.create_agent(
-            current_user.id,
-            name=payload.name.strip(),
-            hostname=payload.hostname.strip(),
-            port=payload.port,
-            username=payload.username.strip(),
-            private_key=payload.private_key,
-            private_key_passphrase=payload.private_key_passphrase,
-            allow_unknown_hosts=payload.allow_unknown_hosts,
-            known_hosts_path=payload.known_hosts_path.strip() if payload.known_hosts_path else None,
-        )
-        return agent_to_response(agent)
 
     @protected_router.get("/agents/{agent_id}", response_model=AgentResponse)
     async def read_agent(agent: Agent = Depends(get_agent)) -> AgentResponse:

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -55,41 +55,58 @@
             <span class="badge">Prefix: {{ user.api_key_prefix }}</span>
         </div>
         <p class="muted">Remote agents authenticate with this key when calling <code>{{ api_base_url }}</code>. Rotate immediately if you suspect a compromise.</p>
+        {% set visible_api_key = revealed_api_key or generated_api_key %}
+        <div class="notice warning">
+            <p><strong>Protect this secret.</strong> Anyone with the full API key can manage your hypervisors. Reveal it only in a trusted environment and rotate immediately if you suspect exposure.</p>
+        </div>
         <div class="notice">
             <p><strong>API endpoint:</strong> <code>{{ api_base_url }}</code></p>
-            {% if generated_api_key %}
-                <p><strong>New API key:</strong></p>
-                <pre><code>{{ generated_api_key }}</code></pre>
-                <p class="help-text">Copy the token now—this is the only time it will be displayed.</p>
-            {% else %}
-                <p><strong>Current key prefix:</strong> <code>{{ user.api_key_prefix }}</code></p>
-            {% endif %}
+            <p><strong>Current key prefix:</strong> <code>{{ user.api_key_prefix }}</code></p>
         </div>
-        <form method="post" action="{{ request.url_for('rotate_api_key') }}">
-            <button type="submit" class="button danger">Rotate API key</button>
-        </form>
+        {% if visible_api_key %}
+            <div class="notice danger">
+                <p><strong>Full API key:</strong></p>
+                <pre><code>{{ visible_api_key }}</code></pre>
+                {% if revealed_api_key %}
+                    <p class="help-text">Rotate the credential if this value was displayed somewhere unsafe.</p>
+                {% else %}
+                    <p class="help-text">Copy the token now—this is the only time it will be displayed after rotation.</p>
+                {% endif %}
+            </div>
+        {% endif %}
+        <div class="grid-2">
+            <section>
+                <h3>Reveal current key</h3>
+                <form method="post" action="{{ request.url_for('reveal_api_key') }}">
+                    <div class="field">
+                        <label for="reveal-password">Account password</label>
+                        <input type="password" id="reveal-password" name="password" required autocomplete="current-password">
+                    </div>
+                    <p class="help-text">Confirm your identity to decrypt and display the existing API key.</p>
+                    <button type="submit" class="button secondary">Reveal API key</button>
+                </form>
+            </section>
+            <section>
+                <h3>Rotate key</h3>
+                <form method="post" action="{{ request.url_for('rotate_api_key') }}">
+                    <p class="help-text">Issuing a new key immediately revokes the previous secret.</p>
+                    <button type="submit" class="button danger">Rotate API key</button>
+                </form>
+            </section>
+        </div>
         <p style="margin-top: 1.5rem;">Provision the remote agent environment file on your hypervisor:</p>
 <pre><code>sudo install -d -m 700 /etc/playrservers
 sudo tee /etc/playrservers/agent.env &gt; /dev/null &lt;&lt;'CONFIG'
 API_BASE_URL={{ api_base_url }}
-API_KEY={{ generated_api_key or '&lt;your-api-key&gt;' }}
+API_KEY={{ visible_api_key or '&lt;your-api-key&gt;' }}
 CONFIG
 sudo chmod 600 /etc/playrservers/agent.env
 </code></pre>
-        <p>With the agent configured, enroll the host via cURL:</p>
-<pre><code>source /etc/playrservers/agent.env
-curl -X POST "$API_BASE_URL/agents" \
-  -H "Authorization: Bearer $API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-        "name": "hypervisor-01",
-        "hostname": "203.0.113.42",
-        "port": 22,
-        "username": "qemu-admin",
-        "private_key": "$(cat /etc/playrservers/ssh/id_ed25519)"
-      }'
+        <p>After configuring the environment, restart the agent to trigger pairing:</p>
+<pre><code>sudo systemctl restart playrservers-agent
+sudo journalctl -u playrservers-agent -n 50
 </code></pre>
-        <p class="muted">The control plane operations team maintains <code>{{ api_base_url }}</code>; reference this URL when configuring agents to reach the API listener (<code>MANAGEMENT_API_PORT</code>, <code>8001</code> by default).</p>
+        <p class="muted">The agent calls <code>POST /v1/servers/connect</code> on startup to register the host using the credentials above.</p>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/management.html
+++ b/app/templates/management.html
@@ -37,48 +37,22 @@
                             </div>
                         {% endfor %}
                     {% else %}
-                        <p class="muted">No hypervisors registered yet. Use the form to onboard your first agent.</p>
+                        <p class="muted">No hypervisors are paired yet. Install and start the PlayrServers agent on a host to enrol it automatically.</p>
                     {% endif %}
                 </div>
             </section>
             <section>
-                <h2>Add hypervisor</h2>
-                <form method="post" action="{{ request.url_for('register_agent') }}">
-                    <div class="field">
-                        <label for="agent-name">Name</label>
-                        <input type="text" id="agent-name" name="name" required placeholder="hypervisor-01">
-                    </div>
-                    <div class="field">
-                        <label for="agent-hostname">Hostname / IP</label>
-                        <input type="text" id="agent-hostname" name="hostname" required placeholder="203.0.113.42">
-                    </div>
-                    <div class="field">
-                        <label for="agent-port">SSH port</label>
-                        <input type="number" id="agent-port" name="port" value="22" min="1" max="65535" required>
-                    </div>
-                    <div class="field">
-                        <label for="agent-username">SSH username</label>
-                        <input type="text" id="agent-username" name="username" required placeholder="qemu-admin">
-                    </div>
-                    <div class="field">
-                        <label for="agent-key">Private key</label>
-                        <textarea id="agent-key" name="private_key" required placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"></textarea>
-                    </div>
-                    <div class="field">
-                        <label for="agent-passphrase">Private key passphrase <span class="muted">(optional)</span></label>
-                        <input type="password" id="agent-passphrase" name="private_key_passphrase" autocomplete="off">
-                    </div>
-                    <div class="field">
-                        <label for="agent-known-hosts">Known hosts path <span class="muted">(optional)</span></label>
-                        <input type="text" id="agent-known-hosts" name="known_hosts_path" placeholder="~/.ssh/known_hosts">
-                    </div>
-                    <div class="field" style="flex-direction: row; align-items: center; gap: 0.75rem;">
-                        <input type="checkbox" id="agent-allow-unknown" name="allow_unknown_hosts" value="1">
-                        <label for="agent-allow-unknown">Allow unknown host keys</label>
-                    </div>
-                    <p class="help-text">Upload a dedicated automation key. The control plane stores the private key encrypted at rest.</p>
-                    <button type="submit" class="button">Register hypervisor</button>
-                </form>
+                <h2>Pair hypervisors</h2>
+                <div class="notice warning">
+                    <p><strong>Agent pairing required.</strong> Manual onboarding with raw SSH credentials has been disabled. Install the PlayrServers agent service on each host to register it with the control plane.</p>
+                </div>
+                <p>Once the agent connects using your automation API key, the hypervisor appears in this list automatically. Keep the agent running to ensure SSH keys and metadata stay synchronized.</p>
+                <ol>
+                    <li>Install the <strong>HVDeploy</strong> agent on the target hypervisor.</li>
+                    <li>Create <code>/etc/playrservers/agent.env</code> with the API base URL and key from your <a href="{{ request.url_for('account') }}">account page</a>.</li>
+                    <li>Start the agent service; it will call <code>POST /v1/servers/connect</code> to enrol the host.</li>
+                </ol>
+                <p class="help-text">Need the agent toolkit? The operations team maintains download links and deployment guides in the remote agent section below.</p>
             </section>
         </div>
     </div>
@@ -90,7 +64,7 @@
         </div>
         <div id="vm-status" class="muted">
             {% if not agents %}
-                Register a hypervisor to view its virtual machines.
+                Pair a hypervisor with the agent service to view its virtual machines.
             {% elif not selected_agent %}
                 Select a hypervisor to load its virtual machines.
             {% else %}
@@ -118,7 +92,7 @@
         </div>
         <div id="deployment-placeholder" class="placeholder-box"{% if selected_agent %} style="display: none;"{% endif %}>
             {% if not agents %}
-                Register a hypervisor to enable guided VM deployments.
+                Pair a hypervisor with the agent service to enable guided VM deployments.
             {% elif not selected_agent %}
                 Select a hypervisor to prepare an automated operating system installation.
             {% endif %}
@@ -198,7 +172,7 @@
         </div>
         <div id="vm-console-placeholder" class="placeholder-box">
             {% if not agents %}
-                Register a hypervisor to access guest consoles.
+                Pair a hypervisor with the agent service to access guest consoles.
             {% elif not selected_agent %}
                 Select a hypervisor and choose a VM to open its console.
             {% else %}
@@ -229,7 +203,7 @@
         </div>
         <div id="host-info-placeholder" class="placeholder-box">
             {% if not agents %}
-                Register a hypervisor to monitor its performance metrics.
+                Pair a hypervisor with the agent service to monitor its performance metrics.
             {% elif not selected_agent %}
                 Select a hypervisor to view system metrics.
             {% else %}
@@ -1034,7 +1008,7 @@
             deploymentPlaceholder.style.display = '';
             deploymentPlaceholder.textContent = state.agents.length
                 ? 'Select a hypervisor to prepare an automated operating system installation.'
-                : 'Register a hypervisor to enable guided VM deployments.';
+                : 'Pair a hypervisor with the agent service to enable guided VM deployments.';
             setDeploymentStatus('Select a hypervisor to deploy.', false);
             return;
         }
@@ -1567,7 +1541,7 @@
             vmConsolePlaceholder.style.display = '';
             vmConsolePlaceholder.textContent = state.agents.length
                 ? 'Select a hypervisor and choose a VM to open its console.'
-                : 'Register a hypervisor to access guest consoles.';
+                : 'Pair a hypervisor with the agent service to access guest consoles.';
             vmConsoleSection.style.display = 'none';
             disconnectVmConsole(false);
             if (vmConsoleLabel) {
@@ -2184,7 +2158,7 @@
         if (!agent) {
             const message = state.agents.length
                 ? 'Select a hypervisor to view system metrics.'
-                : 'Register a hypervisor to monitor its performance metrics.';
+                : 'Pair a hypervisor with the agent service to monitor its performance metrics.';
             showHostInfoPlaceholder(message, 'Idle');
             return;
         }
@@ -2246,7 +2220,7 @@
         if (!state.agents.length) {
             const empty = document.createElement('p');
             empty.className = 'muted';
-            empty.textContent = 'No hypervisors registered yet. Use the form to onboard your first agent.';
+            empty.textContent = 'No hypervisors are paired yet. Install and start the PlayrServers agent on a host to enrol it automatically.';
             agentList.appendChild(empty);
             return;
         }
@@ -2582,8 +2556,8 @@
         setVmStatus('Select a hypervisor to load its virtual machines.');
         showHostInfoPlaceholder('Select a hypervisor to view system metrics.');
     } else {
-        setVmStatus('Register a hypervisor to view its virtual machines.');
-        showHostInfoPlaceholder('Register a hypervisor to monitor its performance metrics.');
+        setVmStatus('Pair a hypervisor with the agent service to view its virtual machines.');
+        showHostInfoPlaceholder('Pair a hypervisor with the agent service to monitor its performance metrics.');
     }
 
     refreshDeploymentSummaries({ manual: true });

--- a/tests/test_agent_registration.py
+++ b/tests/test_agent_registration.py
@@ -175,6 +175,25 @@ def test_agent_registration_updates_when_ip_changes(tmp_path: Path):
     assert agent.name == "hv-01"
 
 
+def test_manual_agent_creation_endpoint_removed(tmp_path: Path):
+    app, _, _, api_key, _, _ = _build_app(tmp_path)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/agents",
+            headers=_auth_header(api_key),
+            json={
+                "name": "legacy-agent",
+                "hostname": "198.51.100.25",
+                "port": 22,
+                "username": "hvdeploy",
+                "private_key": "dummy",
+            },
+        )
+
+    assert response.status_code in {404, 405}
+
+
 def test_private_key_cannot_be_retrieved_via_api(tmp_path: Path):
     app, database, user, api_key, _, _ = _build_app(tmp_path)
 


### PR DESCRIPTION
## Summary
- remove manual hypervisor onboarding, update the UI copy, and disable the /agents creation route so pairing happens through the agent service
- encrypt stored API keys, add a password-protected reveal flow, and show a warning when the key is displayed
- document the new workflow and extend tests to cover revealing the API key and rejecting manual agent creation

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce8740fba8833195b730b1bdc25e58