### PR TITLE
Add SSH terminal WebSocket to API

### DIFF
--- a/app/terminals.py
+++ b/app/terminals.py
@@ -1,0 +1,135 @@
+"""Utilities for streaming SSH terminals over WebSockets."""
+from __future__ import annotations
+
+import inspect
+import json
+from contextlib import suppress
+from typing import Any, Awaitable, Callable
+
+import anyio
+from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+
+CloseCallback = Callable[[], Awaitable[None] | None] | None
+
+
+async def send_websocket_json(websocket: WebSocket, payload: dict[str, Any]) -> None:
+    """Safely send a JSON payload to a websocket client."""
+
+    if websocket.client_state == WebSocketState.DISCONNECTED:
+        return
+    with suppress(Exception):
+        await websocket.send_json(payload)
+
+
+async def stream_ssh_channel(
+    websocket: WebSocket,
+    channel: Any,
+    *,
+    on_close: CloseCallback = None,
+) -> None:
+    """Bridge data between a websocket and an interactive SSH channel."""
+
+    cancel_exc = anyio.get_cancelled_exc_class()
+    closed = False
+
+    async def cleanup() -> None:
+        nonlocal closed
+        if closed:
+            return
+        closed = True
+        if on_close is not None:
+            try:
+                result = on_close()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                pass
+        with suppress(Exception):
+            await anyio.to_thread.run_sync(channel.close, abandon_on_cancel=True)
+        with suppress(Exception):
+            if websocket.application_state != WebSocketState.DISCONNECTED:
+                await websocket.close()
+
+    async def pump_ssh_to_websocket(task_group) -> None:
+        try:
+            while True:
+                data = await anyio.to_thread.run_sync(
+                    channel.recv,
+                    4096,
+                    abandon_on_cancel=True,
+                )
+                if not data:
+                    break
+                try:
+                    await websocket.send_bytes(data)
+                except Exception:
+                    break
+        except cancel_exc:
+            pass
+        except Exception:
+            pass
+        finally:
+            task_group.cancel_scope.cancel()
+            await cleanup()
+
+    async def pump_websocket_to_ssh(task_group) -> None:
+        try:
+            while True:
+                message = await websocket.receive()
+                if message["type"] == "websocket.disconnect":
+                    break
+                data = message.get("bytes")
+                if data is not None:
+                    if data:
+                        with suppress(Exception):
+                            await anyio.to_thread.run_sync(channel.send, data)
+                    continue
+                text = message.get("text")
+                if text is None:
+                    continue
+                try:
+                    payload = json.loads(text)
+                except json.JSONDecodeError:
+                    encoded = text.encode("utf-8", errors="ignore")
+                    if encoded:
+                        with suppress(Exception):
+                            await anyio.to_thread.run_sync(channel.send, encoded)
+                    continue
+                message_type = payload.get("type")
+                if message_type == "resize":
+                    cols = payload.get("cols")
+                    rows = payload.get("rows")
+                    try:
+                        width = int(cols) if cols else 0
+                    except (TypeError, ValueError):
+                        width = 0
+                    try:
+                        height = int(rows) if rows else 0
+                    except (TypeError, ValueError):
+                        height = 0
+                    width = width if width > 0 else 80
+                    height = height if height > 0 else 24
+                    with suppress(Exception):
+                        await anyio.to_thread.run_sync(channel.resize_pty, width, height)
+                    continue
+                if message_type == "close":
+                    break
+        except (WebSocketDisconnect, cancel_exc):
+            pass
+        except Exception:
+            pass
+        finally:
+            task_group.cancel_scope.cancel()
+            await cleanup()
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(pump_ssh_to_websocket, task_group)
+        task_group.start_soon(pump_websocket_to_ssh, task_group)
+
+    await cleanup()
+
+
+__all__ = ["send_websocket_json", "stream_ssh_channel"]
+

--- a/tests/test_api_terminal.py
+++ b/tests/test_api_terminal.py
@@ -1,0 +1,165 @@
+import json
+import os
+import queue
+import sys
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("MANAGEMENT_SESSION_SECRET", "tests-secret-key")
+
+from app.api import create_app
+from app.database import Database
+from app.security import APIKeyAuth
+
+
+EMAIL = "terminal@example.com"
+PASSWORD = "super-secret"
+
+
+class DummyChannel:
+    def __init__(self) -> None:
+        self.sent = []
+        self.resizes = []
+        self.closed = False
+        self.send_event = threading.Event()
+        self.resize_event = threading.Event()
+        self._queue = queue.Queue()
+
+    def queue_data(self, data: bytes) -> None:
+        self._queue.put(data)
+
+    def recv(self, _size: int) -> bytes:
+        return self._queue.get()
+
+    def send(self, data: bytes) -> int:
+        payload = bytes(data)
+        self.sent.append(payload)
+        self.send_event.set()
+        return len(payload)
+
+    def resize_pty(self, width: int, height: int) -> None:
+        self.resizes.append((width, height))
+        self.resize_event.set()
+
+    def close(self) -> None:
+        if not self.closed:
+            self.closed = True
+            self._queue.put(b"")
+
+
+def _auth_header(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def test_api_terminal_websocket_requires_authentication(tmp_path):
+    database = Database(tmp_path / "management.sqlite3")
+    database.initialize()
+
+    user, api_key = database.create_user("Operator", EMAIL, PASSWORD)
+    agent = database.create_agent(
+        user.id,
+        name="hypervisor-01",
+        hostname="hv.internal",
+        port=22,
+        username="qemu",
+        private_key="dummy",
+        private_key_passphrase=None,
+        allow_unknown_hosts=True,
+        known_hosts_path=None,
+    )
+
+    app = create_app(
+        database=database,
+        auth=APIKeyAuth(database),
+    )
+
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect(f"/agents/{agent.id}/terminal"):
+                pass
+        assert excinfo.value.code == 4401
+
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect(
+                f"/agents/{agent.id}/terminal",
+                headers=_auth_header("invalid"),
+            ):
+                pass
+        assert excinfo.value.code == 4403
+
+
+def test_api_terminal_websocket_streams_data(tmp_path):
+    database = Database(tmp_path / "management.sqlite3")
+    database.initialize()
+
+    user, api_key = database.create_user("Operator", EMAIL, PASSWORD)
+    agent = database.create_agent(
+        user.id,
+        name="hypervisor-01",
+        hostname="hv.internal",
+        port=22,
+        username="qemu",
+        private_key="dummy",
+        private_key_passphrase=None,
+        allow_unknown_hosts=True,
+        known_hosts_path=None,
+    )
+
+    app = create_app(
+        database=database,
+        auth=APIKeyAuth(database),
+    )
+
+    channels: list[DummyChannel] = []
+
+    def terminal_factory(requested_agent):
+        assert requested_agent.id == agent.id
+        channel = DummyChannel()
+        channels.append(channel)
+
+        @contextmanager
+        def manager():
+            try:
+                yield channel
+            finally:
+                channel.close()
+
+        return manager()
+
+    app.state.ssh_terminal_factory = terminal_factory
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            f"/agents/{agent.id}/terminal",
+            headers=_auth_header(api_key),
+        ) as websocket:
+            message = websocket.receive_json()
+            assert message["type"] == "status"
+            assert message["status"] == "connected"
+
+            channel = channels[0]
+            channel.queue_data(b"welcome\n")
+            assert websocket.receive_bytes() == b"welcome\n"
+
+            websocket.send_bytes(b"ls\n")
+            assert channel.send_event.wait(timeout=1)
+            assert channel.sent[-1] == b"ls\n"
+
+            websocket.send_text(json.dumps({"type": "resize", "cols": 120, "rows": 40}))
+            assert channel.resize_event.wait(timeout=1)
+            assert channel.resizes[-1] == (120, 40)
+
+            websocket.send_text(json.dumps({"type": "close"}))
+
+    assert channels[0].closed is True
+


### PR DESCRIPTION
## Summary
* add a websocket endpoint under the API to expose SSH terminal access secured by API keys
* extract shared websocket streaming helpers so both the API and management UI reuse the same logic
* add automated coverage that exercises authentication and terminal streaming over the API websocket

## Testing
* pytest

------
https://chatgpt.com/codex/tasks/task_e_68cebffce0c88331b88ebacaae1b8ec1