### PR TITLE
Route management SSH via API relay

### DIFF
--- a/app/api_runner.py
+++ b/app/api_runner.py
@@ -1,0 +1,163 @@
+"""HTTP-backed SSH command runner for interacting with the management API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import httpx
+
+from .ssh import CommandResult, HostKeyVerificationError, SSHError
+
+
+@dataclass
+class _RunnerConfig:
+    base_url: str
+    api_key: str
+    agent_id: int
+    hostname: str
+    port: int
+    timeout: float
+
+
+def _normalize_base_url(base_url: str) -> str:
+    cleaned = (base_url or "").strip()
+    if not cleaned:
+        raise ValueError("API base URL must not be empty")
+    return cleaned.rstrip("/")
+
+
+def _build_endpoint(base_url: str, path: str) -> str:
+    if not path.startswith("/"):
+        path = "/" + path
+    return f"{base_url}{path}"
+
+
+def _extract_error_message(payload: object, default: str) -> str:
+    if isinstance(payload, dict):
+        for key in ("message", "detail", "error"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    if isinstance(payload, str) and payload.strip():
+        return payload.strip()
+    return default
+
+
+class APICommandRunner:
+    """Execute SSH commands by delegating to the management API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        *,
+        agent_id: int,
+        hostname: str,
+        port: int,
+        timeout: float = 30.0,
+    ) -> None:
+        self._config = _RunnerConfig(
+            base_url=_normalize_base_url(base_url),
+            api_key=api_key.strip(),
+            agent_id=agent_id,
+            hostname=hostname,
+            port=port,
+            timeout=timeout,
+        )
+        if not self._config.api_key:
+            raise ValueError("API key must not be empty when using APICommandRunner")
+
+    def run(self, args: Sequence[str], timeout: int = 60) -> CommandResult:
+        command = [str(part) for part in args]
+        if not command:
+            raise SSHError("SSH command must not be empty")
+
+        url = _build_endpoint(
+            self._config.base_url,
+            f"/agents/{self._config.agent_id}/ssh/command",
+        )
+
+        headers = {"Authorization": f"Bearer {self._config.api_key}"}
+        payload = {"command": command, "timeout": timeout}
+
+        try:
+            response = httpx.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=self._config.timeout,
+            )
+        except httpx.RequestError as exc:  # pragma: no cover - network failure
+            raise SSHError(f"Failed to contact SSH relay API: {exc}") from exc
+
+        if response.status_code >= 400:
+            message = f"SSH relay API request failed with status {response.status_code}"
+            detail_payload: object | None = None
+            try:
+                parsed = response.json()
+            except ValueError:
+                parsed = None
+
+            if isinstance(parsed, dict):
+                detail = parsed.get("detail")
+                if isinstance(detail, dict):
+                    code = detail.get("code")
+                    if code == "host_key_verification_failed":
+                        hostname = detail.get("hostname") or self._config.hostname
+                        port = detail.get("port") or self._config.port
+                        suggestion = detail.get("suggestion")
+                        raise HostKeyVerificationError(
+                            hostname,
+                            port=port,
+                            suggestion=suggestion,
+                        )
+                    detail_payload = detail
+                    message = _extract_error_message(detail, message)
+                else:
+                    detail_payload = parsed
+                    message = _extract_error_message(parsed, message)
+            elif parsed is not None:
+                detail_payload = parsed
+                message = _extract_error_message(parsed, message)
+
+            if response.status_code == 401:
+                raise SSHError("Authentication with the SSH relay API failed")
+            if response.status_code == 403:
+                raise SSHError("The SSH relay API denied access to this hypervisor")
+            if response.status_code == 404:
+                raise SSHError("Hypervisor not found in the SSH relay API")
+
+            raise SSHError(message)
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise SSHError("SSH relay API returned an invalid response") from exc
+
+        if not isinstance(data, dict):
+            raise SSHError("SSH relay API returned an unexpected response payload")
+
+        try:
+            command_result = data["command"]
+            exit_status = int(data["exit_status"])
+            stdout = str(data.get("stdout", ""))
+            stderr = str(data.get("stderr", ""))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise SSHError("SSH relay API response was missing required fields") from exc
+
+        if not isinstance(command_result, (list, tuple)):
+            raise SSHError("SSH relay API returned an invalid command description")
+
+        normalized_command = [str(part) for part in command_result]
+
+        return CommandResult(
+            command=tuple(normalized_command),
+            exit_status=exit_status,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+
+__all__ = ["APICommandRunner"]
+

--- a/app/terminals.py
+++ b/app/terminals.py
@@ -48,6 +48,11 @@ async def stream_ssh_channel(
                 pass
         with suppress(Exception):
             await anyio.to_thread.run_sync(channel.close, abandon_on_cancel=True)
+            if hasattr(channel, "closed"):
+                try:
+                    setattr(channel, "closed", True)
+                except Exception:
+                    pass
         with suppress(Exception):
             if websocket.application_state != WebSocketState.DISCONNECTED:
                 await websocket.close()
@@ -115,6 +120,7 @@ async def stream_ssh_channel(
                         await anyio.to_thread.run_sync(channel.resize_pty, width, height)
                     continue
                 if message_type == "close":
+                    await cleanup()
                     break
         except (WebSocketDisconnect, cancel_exc):
             pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyYAML==6.0.1
 Jinja2==3.1.3
 passlib[bcrypt]==1.7.4
 httpx==0.27.2
+websockets==12.0

--- a/tests/test_api_ssh_command.py
+++ b/tests/test_api_ssh_command.py
@@ -1,0 +1,180 @@
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("MANAGEMENT_SESSION_SECRET", "tests-secret-key")
+
+from app.api import create_app
+from app.api_runner import APICommandRunner
+from app.database import Database
+from app.ssh import CommandResult, HostKeyVerificationError, SSHError
+
+
+EMAIL = "api-command@example.com"
+PASSWORD = "super-secret"
+
+
+class DummySSHRunner:
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def run(self, _command, timeout: int = 60) -> CommandResult:
+        return CommandResult(
+            command=["echo", "hello"],
+            exit_status=0,
+            stdout="hello\n",
+            stderr="",
+        )
+
+
+@pytest.fixture
+def api_app(tmp_path):
+    database = Database(tmp_path / "management.sqlite3")
+    database.initialize()
+    user, api_key = database.create_user("Operator", EMAIL, PASSWORD)
+    agent = database.create_agent(
+        user.id,
+        name="hypervisor-01",
+        hostname="hv.internal",
+        port=22,
+        username="qemu",
+        private_key="dummy",
+        private_key_passphrase=None,
+        allow_unknown_hosts=True,
+        known_hosts_path=None,
+    )
+
+    app = create_app(database=database)
+    yield app, database, user, api_key, agent
+
+
+def test_api_ssh_command_endpoint_returns_result(api_app, monkeypatch):
+    app, database, user, api_key, agent = api_app
+
+    class Runner(DummySSHRunner):
+        pass
+
+    monkeypatch.setattr("app.api.SSHCommandRunner", Runner)
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/agents/{agent.id}/ssh/command",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"command": ["echo", "hello"], "timeout": 5},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "command": ["echo", "hello"],
+        "exit_status": 0,
+        "stdout": "hello\n",
+        "stderr": "",
+    }
+
+
+def test_api_ssh_command_endpoint_handles_host_key_error(api_app, monkeypatch):
+    app, database, user, api_key, agent = api_app
+
+    class Runner:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def run(self, _command, timeout: int = 60):
+            raise HostKeyVerificationError(agent.hostname, port=agent.port, suggestion="check host")
+
+    monkeypatch.setattr("app.api.SSHCommandRunner", Runner)
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/agents/{agent.id}/ssh/command",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"command": ["uptime"]},
+        )
+
+    assert response.status_code == 502
+    payload = response.json()
+    assert payload["detail"]["code"] == "host_key_verification_failed"
+    assert payload["detail"]["hostname"] == agent.hostname
+    assert payload["detail"]["port"] == agent.port
+
+
+def test_api_command_runner_success(monkeypatch):
+    result_payload = {
+        "command": ["virsh", "list"],
+        "exit_status": 0,
+        "stdout": "ok",
+        "stderr": "",
+    }
+
+    def fake_post(url, json=None, headers=None, timeout=None):  # noqa: A002
+        return httpx.Response(200, json=result_payload)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    runner = APICommandRunner(
+        "https://api.example.com",
+        "api-key",
+        agent_id=1,
+        hostname="hv.internal",
+        port=22,
+    )
+
+    result = runner.run(["virsh", "list"])
+    assert result.command == tuple(result_payload["command"])
+    assert result.exit_status == 0
+    assert result.stdout == "ok"
+
+
+def test_api_command_runner_host_key_error(monkeypatch):
+    detail = {
+        "detail": {
+            "code": "host_key_verification_failed",
+            "message": "verification failed",
+            "hostname": "hv.internal",
+            "port": 22,
+        }
+    }
+
+    def fake_post(url, json=None, headers=None, timeout=None):  # noqa: A002
+        return httpx.Response(502, json=detail)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    runner = APICommandRunner(
+        "https://api.example.com",
+        "api-key",
+        agent_id=1,
+        hostname="hv.internal",
+        port=22,
+    )
+
+    with pytest.raises(HostKeyVerificationError):
+        runner.run(["virsh", "list"])
+
+
+def test_api_command_runner_http_error(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=None):  # noqa: A002
+        return httpx.Response(401, json={"detail": "unauthorized"})
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    runner = APICommandRunner(
+        "https://api.example.com",
+        "api-key",
+        agent_id=1,
+        hostname="hv.internal",
+        port=22,
+    )
+
+    with pytest.raises(SSHError) as excinfo:
+        runner.run(["virsh", "list"])
+    assert "Authentication" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- introduce an API-backed SSH command runner so the management UI executes
  commands through the public API instead of dialing hypervisors directly
- bridge management WebSocket sessions to the API's SSH/console relays and add a
  dedicated API endpoint for issuing arbitrary SSH commands
- add regression tests covering the new API command endpoint and the runner

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ceddf254948331974a93fb59d7c429