### PR TITLE
Use internal API base for management SSH calls

### DIFF
--- a/app/api_runner.py
+++ b/app/api_runner.py
@@ -56,6 +56,7 @@ class APICommandRunner:
         hostname: str,
         port: int,
         timeout: float = 30.0,
+        verify: str | bool | None = None,
     ) -> None:
         self._config = _RunnerConfig(
             base_url=_normalize_base_url(base_url),
@@ -67,6 +68,7 @@ class APICommandRunner:
         )
         if not self._config.api_key:
             raise ValueError("API key must not be empty when using APICommandRunner")
+        self._verify = verify
 
     def run(self, args: Sequence[str], timeout: int = 60) -> CommandResult:
         command = [str(part) for part in args]
@@ -87,6 +89,7 @@ class APICommandRunner:
                 json=payload,
                 headers=headers,
                 timeout=self._config.timeout,
+                verify=self._verify,
             )
         except httpx.RequestError as exc:  # pragma: no cover - network failure
             raise SSHError(f"Failed to contact SSH relay API: {exc}") from exc

--- a/app/application.py
+++ b/app/application.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import os
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Tuple
 
 from fastapi import FastAPI
 
@@ -14,6 +15,59 @@ from .security import APIKeyAuth
 
 def _resolve_public_api_url() -> str:
     return os.getenv("MANAGEMENT_PUBLIC_API_URL", "https://api.playrservers.com")
+
+
+def _env_flag(value: Optional[str], default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_verify_setting(value: str) -> Optional[str | bool]:
+    lowered = value.strip().lower()
+    if lowered in {"", "default"}:
+        return None
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    path = Path(value).expanduser()
+    return str(path)
+
+
+def _resolve_internal_api_settings() -> Tuple[Optional[str], Optional[str | bool]]:
+    custom_base = os.getenv("MANAGEMENT_INTERNAL_API_URL")
+    verify_setting = os.getenv("MANAGEMENT_INTERNAL_API_VERIFY")
+
+    if custom_base:
+        cleaned = custom_base.strip().rstrip("/")
+        verify = _parse_verify_setting(verify_setting) if verify_setting else None
+        return cleaned or None, verify
+
+    port = int(os.getenv("MANAGEMENT_PORT", "443"))
+    disable_tls = _env_flag(os.getenv("MANAGEMENT_DISABLE_TLS"), False)
+    scheme = "http" if disable_tls else "https"
+    host = os.getenv("MANAGEMENT_INTERNAL_API_HOST", "127.0.0.1").strip() or "127.0.0.1"
+
+    base_url = f"{scheme}://{host}:{port}/api"
+
+    if disable_tls:
+        return base_url, None
+
+    cert_path = os.getenv("MANAGEMENT_SSL_CERTFILE")
+    if cert_path:
+        candidate = Path(cert_path).expanduser()
+    else:
+        project_root = Path(__file__).resolve().parent.parent
+        candidate = project_root / "config" / "tls" / "server.crt"
+
+    verify: str | bool
+    if candidate.exists():
+        verify = str(candidate)
+    else:
+        verify = False
+
+    return base_url, verify
 
 
 def create_application(
@@ -29,10 +83,14 @@ def create_application(
     api_auth = APIKeyAuth(database)
     api_app = create_api_app(database=database, auth=api_auth)
 
+    internal_api_base_url, internal_api_verify = _resolve_internal_api_settings()
+
     management_app = create_management_app(
         database=database,
         api_base_url=_resolve_public_api_url(),
         session_secret=os.getenv("MANAGEMENT_SESSION_SECRET"),
+        internal_api_base_url=internal_api_base_url,
+        internal_api_verify=internal_api_verify,
     )
 
     app = FastAPI(

--- a/tests/test_management_internal_api.py
+++ b/tests/test_management_internal_api.py
@@ -1,0 +1,89 @@
+import os
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("MANAGEMENT_SESSION_SECRET", "tests-secret-key")
+
+from app.database import Database
+from app.management import create_app
+from app.ssh import CommandResult
+import app.management as management_module
+
+
+EMAIL = "internal@example.com"
+PASSWORD = "super-secret"
+
+
+def test_management_uses_internal_api_configuration(monkeypatch, tmp_path):
+    database = Database(tmp_path / "management.sqlite3")
+    database.initialize()
+
+    user, _ = database.create_user("Operator", EMAIL, PASSWORD)
+    agent = database.create_agent(
+        user.id,
+        name="hypervisor-01",
+        hostname="hv.internal",
+        port=22,
+        username="qemu",
+        private_key="dummy",
+        private_key_passphrase=None,
+        allow_unknown_hosts=True,
+        known_hosts_path=None,
+    )
+
+    captured = {}
+
+    def fake_runner(base_url, api_key, *, agent_id, hostname, port, verify=None):  # noqa: D401
+        captured.update(
+            {
+                "base_url": base_url,
+                "verify": verify,
+                "agent_id": agent_id,
+                "hostname": hostname,
+                "port": port,
+            }
+        )
+
+        class Runner:
+            def run(self, args, timeout: int = 60) -> CommandResult:
+                stdout = (
+                    " Id   Name               State\n"
+                    "---------------------------------\n"
+                    " 1    vm01               running\n"
+                )
+                return CommandResult(command=args, exit_status=0, stdout=stdout, stderr="")
+
+        return Runner()
+
+    monkeypatch.setattr(management_module, "APICommandRunner", fake_runner)
+
+    app = create_app(
+        database=database,
+        session_secret="tests-secret",
+        api_base_url="https://public.example.com",
+        internal_api_base_url="https://internal.example.com/api",
+        internal_api_verify="/tmp/internal-ca.pem",
+    )
+
+    with TestClient(app) as client:
+        login = client.post(
+            "/login",
+            data={"email": EMAIL, "password": PASSWORD},
+            follow_redirects=False,
+        )
+        assert login.status_code == 303
+
+        response = client.get(f"/management/agents/{agent.id}/vms")
+        assert response.status_code == 200
+
+    assert captured["base_url"] == "https://internal.example.com/api"
+    assert captured["verify"] == "/tmp/internal-ca.pem"
+    assert captured["agent_id"] == agent.id
+    assert captured["hostname"] == agent.hostname
+    assert captured["port"] == agent.port


### PR DESCRIPTION
## Summary
- allow `APICommandRunner` to accept an optional TLS verify parameter when calling the automation API
- resolve internal API routing details in the combined application and propagate them to the management UI so server-side SSH commands use the loopback base by default (with env overrides)
- exercise the new behaviour with unit tests covering both the verify flag and internal API wiring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceec6ea6ac833196ce7d212a433d07