### PR TITLE
Add management service HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,15 @@ clean foundation.
 - ✅ **SQLite-backed user storage** – `app.database.Database` persists user
   accounts with hashed passwords. Optional dependencies such as `passlib` remain
   optional; the module provides a PBKDF2 fallback when they are absent.
-- ✅ **Command-line bootstrap** – `scripts/create_user.py` initialises the
-  database (if needed) and adds user records for local testing.
-- ⚠️ **No runtime services** – there is no HTTP API, management UI, or hypervisor
-  automation at this stage. Running `python main.py` simply prepares the
-  database and prints a reminder about the removed components.
+- ✅ **Agent coordination service** – `app.service.create_app()` exposes a
+  FastAPI application that agents use to authenticate, maintain heartbeats, and
+  request encrypted tunnels that terminate on `manage.playrservers.com:443`.
+- ✅ **Command-line bootstrap** – `python main.py` initialises the database by
+  default, while `python main.py serve` launches the HTTP control plane.
 
 ## Getting started
 
-Create a virtual environment and install requirements (none are currently
-mandated, but the command keeps your environment tidy):
+Create a virtual environment and install the web-service dependencies:
 
 ```bash
 python3 -m venv .venv
@@ -36,8 +35,29 @@ python main.py
 python scripts/create_user.py "Test User" test@example.com
 ```
 
-The helper script prompts for a password (minimum 12 characters) and confirms
-that only basic login data is stored.
+### Running the management API
+
+Launch the API using the same credentials you created above:
+
+```bash
+python main.py serve --host 0.0.0.0 --port 8000
+```
+
+Agents authenticate with HTTP Basic credentials (email + password) and interact
+with the following key endpoints:
+
+- `POST /v1/agents/connect` – register an agent and obtain session/tunnel tokens
+- `POST /v1/agents/{agent_id}/heartbeat` – keep the session alive and update
+  tunnel states
+- `POST /v1/agents/{agent_id}/tunnels` – request an authenticated tunnel for SSH
+  or command execution without exposing additional ports
+- `POST /v1/agents/{agent_id}/tunnels/{tunnel_id}/close` – terminate a tunnel
+- `GET /v1/agents/{agent_id}` – retrieve detailed session and tunnel metadata
+
+The API always advertises the public endpoint `manage.playrservers.com:443` to
+agents. Custom host/port values can be supplied at runtime using the
+`--tunnel-host` and `--tunnel-port` flags if you need to point at staging
+infrastructure.
 
 ## Development
 

--- a/app/agents.py
+++ b/app/agents.py
@@ -1,0 +1,390 @@
+"""In-memory coordination primitives for the management control plane."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Dict, Iterable, Mapping
+
+DEFAULT_TUNNEL_HOST = "manage.playrservers.com"
+DEFAULT_TUNNEL_PORT = 443
+DEFAULT_SESSION_TIMEOUT = timedelta(minutes=5)
+
+_MAX_AGENT_ID_LENGTH = 128
+_MAX_HOSTNAME_LENGTH = 255
+_MAX_CAPABILITIES = 32
+_MAX_CAPABILITY_LENGTH = 64
+_MAX_METADATA_ITEMS = 16
+_MAX_METADATA_KEY_LENGTH = 64
+_MAX_METADATA_VALUE_LENGTH = 512
+_ALLOWED_PURPOSE = re.compile(r"^[A-Za-z0-9_.-]{1,32}$")
+_MAX_DESCRIPTION_LENGTH = 512
+
+
+class TunnelState(str, Enum):
+    """Represents the lifecycle state of a tunnel requested by a user."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    CLOSED = "closed"
+
+
+@dataclass
+class Tunnel:
+    """Metadata for an established or pending tunnel."""
+
+    id: str
+    user_id: int
+    purpose: str
+    remote_port: int
+    token: str
+    created_at: datetime
+    updated_at: datetime
+    state: TunnelState = TunnelState.PENDING
+    description: str | None = None
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AgentSession:
+    """Represents a connected agent associated with a single user."""
+
+    agent_id: str
+    user_id: int
+    hostname: str
+    capabilities: tuple[str, ...]
+    metadata: Dict[str, str]
+    session_id: str
+    token: str
+    created_at: datetime
+    last_seen: datetime
+    tunnels: Dict[str, Tunnel] = field(default_factory=dict)
+
+    def expires_at(self, timeout: timedelta) -> datetime:
+        """Return the timestamp after which the session is considered stale."""
+
+        return self.last_seen + timeout
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalise_agent_id(agent_id: str) -> str:
+    value = agent_id.strip()
+    if not value:
+        raise ValueError("Agent identifier must not be empty")
+    if len(value) > _MAX_AGENT_ID_LENGTH:
+        raise ValueError("Agent identifier is too long")
+    return value
+
+
+def _normalise_hostname(hostname: str) -> str:
+    value = hostname.strip()
+    if not value:
+        raise ValueError("Hostname must not be empty")
+    if len(value) > _MAX_HOSTNAME_LENGTH:
+        raise ValueError("Hostname is too long")
+    return value
+
+
+def _normalise_capabilities(capabilities: Iterable[str]) -> tuple[str, ...]:
+    deduplicated: list[str] = []
+    for capability in capabilities:
+        cleaned = capability.strip()
+        if not cleaned:
+            continue
+        if len(cleaned) > _MAX_CAPABILITY_LENGTH:
+            raise ValueError("Capability entries must be 64 characters or fewer")
+        if cleaned in deduplicated:
+            continue
+        deduplicated.append(cleaned)
+        if len(deduplicated) > _MAX_CAPABILITIES:
+            raise ValueError("Too many capabilities provided")
+    return tuple(deduplicated)
+
+
+def _normalise_metadata(metadata: Mapping[str, str] | None) -> Dict[str, str]:
+    if metadata is None:
+        return {}
+    if len(metadata) > _MAX_METADATA_ITEMS:
+        raise ValueError("Too many metadata entries provided")
+    cleaned: Dict[str, str] = {}
+    for key, value in metadata.items():
+        key_text = str(key).strip()
+        value_text = str(value).strip()
+        if not key_text:
+            raise ValueError("Metadata keys must not be empty")
+        if len(key_text) > _MAX_METADATA_KEY_LENGTH:
+            raise ValueError("Metadata keys must be 64 characters or fewer")
+        if len(value_text) > _MAX_METADATA_VALUE_LENGTH:
+            raise ValueError("Metadata values must be 512 characters or fewer")
+        cleaned[key_text] = value_text
+    return cleaned
+
+
+def _normalise_purpose(purpose: str) -> str:
+    value = purpose.strip()
+    if not value:
+        raise ValueError("Purpose must not be empty")
+    if not _ALLOWED_PURPOSE.fullmatch(value):
+        raise ValueError(
+            "Purpose may only contain letters, numbers, underscores, hyphens, or periods",
+        )
+    return value
+
+
+def _normalise_description(description: str | None) -> str | None:
+    if description is None:
+        return None
+    value = description.strip()
+    if not value:
+        return None
+    if len(value) > _MAX_DESCRIPTION_LENGTH:
+        raise ValueError("Description is too long")
+    return value
+
+
+class AgentRegistry:
+    """Tracks connected agents and the tunnels provisioned for them."""
+
+    def __init__(
+        self,
+        *,
+        tunnel_host: str = DEFAULT_TUNNEL_HOST,
+        tunnel_port: int = DEFAULT_TUNNEL_PORT,
+        session_timeout: timedelta = DEFAULT_SESSION_TIMEOUT,
+    ) -> None:
+        self._tunnel_host = tunnel_host
+        self._tunnel_port = tunnel_port
+        self._session_timeout = session_timeout
+        self._lock = asyncio.Lock()
+        self._sessions: Dict[str, AgentSession] = {}
+
+    @property
+    def tunnel_host(self) -> str:
+        return self._tunnel_host
+
+    @property
+    def tunnel_port(self) -> int:
+        return self._tunnel_port
+
+    @property
+    def session_timeout(self) -> timedelta:
+        return self._session_timeout
+
+    async def connect_agent(
+        self,
+        *,
+        agent_id: str,
+        user_id: int,
+        hostname: str,
+        capabilities: Iterable[str],
+        metadata: Mapping[str, str] | None = None,
+    ) -> AgentSession:
+        """Register or refresh an agent connection for a user."""
+
+        normalised_id = _normalise_agent_id(agent_id)
+        normalised_hostname = _normalise_hostname(hostname)
+        normalised_capabilities = _normalise_capabilities(capabilities)
+        normalised_metadata = _normalise_metadata(metadata)
+
+        async with self._lock:
+            self._prune_expired_locked()
+            existing = self._sessions.get(normalised_id)
+            if existing and existing.user_id != user_id:
+                raise PermissionError("Agent is owned by a different user")
+
+            now = _utcnow()
+            session = AgentSession(
+                agent_id=normalised_id,
+                user_id=user_id,
+                hostname=normalised_hostname,
+                capabilities=normalised_capabilities,
+                metadata=normalised_metadata,
+                session_id=secrets.token_hex(16),
+                token=secrets.token_urlsafe(32),
+                created_at=now,
+                last_seen=now,
+            )
+            self._sessions[normalised_id] = session
+            return session
+
+    async def heartbeat(
+        self,
+        *,
+        agent_id: str,
+        user_id: int,
+        session_id: str,
+        token: str,
+        active_tunnels: Iterable[str] | None = None,
+    ) -> AgentSession:
+        """Update the activity timestamp for an agent and refresh tunnel state."""
+
+        normalised_id = _normalise_agent_id(agent_id)
+
+        async with self._lock:
+            self._prune_expired_locked()
+            session = self._sessions.get(normalised_id)
+            if session is None:
+                raise KeyError("Unknown agent")
+            self._ensure_session_is_valid(session, user_id, session_id, token)
+
+            now = _utcnow()
+            session.last_seen = now
+            if active_tunnels is not None:
+                self._update_tunnel_activity(session, active_tunnels, now)
+            return session
+
+    async def create_tunnel(
+        self,
+        *,
+        agent_id: str,
+        user_id: int,
+        session_id: str,
+        token: str,
+        purpose: str,
+        remote_port: int,
+        description: str | None = None,
+        metadata: Mapping[str, str] | None = None,
+    ) -> tuple[Tunnel, AgentSession]:
+        """Provision a new tunnel for the specified agent."""
+
+        if remote_port < 1 or remote_port > 65535:
+            raise ValueError("remote_port must be between 1 and 65535")
+
+        normalised_id = _normalise_agent_id(agent_id)
+        normalised_purpose = _normalise_purpose(purpose)
+        normalised_description = _normalise_description(description)
+        normalised_metadata = _normalise_metadata(metadata)
+
+        async with self._lock:
+            self._prune_expired_locked()
+            session = self._sessions.get(normalised_id)
+            if session is None:
+                raise KeyError("Unknown agent")
+            self._ensure_session_is_valid(session, user_id, session_id, token)
+
+            now = _utcnow()
+            tunnel_id = secrets.token_hex(8)
+            tunnel = Tunnel(
+                id=tunnel_id,
+                user_id=user_id,
+                purpose=normalised_purpose,
+                remote_port=int(remote_port),
+                token=secrets.token_urlsafe(32),
+                created_at=now,
+                updated_at=now,
+                state=TunnelState.PENDING,
+                description=normalised_description,
+                metadata=normalised_metadata,
+            )
+            session.tunnels[tunnel_id] = tunnel
+            session.last_seen = now
+            return tunnel, session
+
+    async def close_tunnel(
+        self,
+        *,
+        agent_id: str,
+        user_id: int,
+        session_id: str,
+        token: str,
+        tunnel_id: str,
+    ) -> tuple[Tunnel, AgentSession]:
+        """Mark a tunnel as closed and update the session heartbeat."""
+
+        normalised_id = _normalise_agent_id(agent_id)
+        normalised_tunnel_id = tunnel_id.strip()
+        if not normalised_tunnel_id:
+            raise ValueError("tunnel_id must not be empty")
+
+        async with self._lock:
+            self._prune_expired_locked()
+            session = self._sessions.get(normalised_id)
+            if session is None:
+                raise KeyError("Unknown agent")
+            self._ensure_session_is_valid(session, user_id, session_id, token)
+
+            tunnel = session.tunnels.get(normalised_tunnel_id)
+            if tunnel is None:
+                raise KeyError("Unknown tunnel")
+
+            now = _utcnow()
+            if tunnel.state != TunnelState.CLOSED:
+                tunnel.state = TunnelState.CLOSED
+                tunnel.updated_at = now
+            session.last_seen = now
+            return tunnel, session
+
+    async def get_session(self, *, agent_id: str, user_id: int) -> AgentSession:
+        """Retrieve session details for the agent if owned by the user."""
+
+        normalised_id = _normalise_agent_id(agent_id)
+
+        async with self._lock:
+            self._prune_expired_locked()
+            session = self._sessions.get(normalised_id)
+            if session is None:
+                raise KeyError("Unknown agent")
+            if session.user_id != user_id:
+                raise PermissionError("Agent is owned by a different user")
+            return session
+
+    def _ensure_session_is_valid(
+        self,
+        session: AgentSession,
+        user_id: int,
+        session_id: str,
+        token: str,
+    ) -> None:
+        if session.user_id != user_id:
+            raise PermissionError("Agent is owned by a different user")
+        if session.session_id != session_id or session.token != token:
+            raise ValueError("Invalid session credentials")
+        if session.expires_at(self._session_timeout) <= _utcnow():
+            raise KeyError("Agent session has expired")
+
+    def _update_tunnel_activity(
+        self,
+        session: AgentSession,
+        active_tunnels: Iterable[str],
+        timestamp: datetime,
+    ) -> None:
+        active = {identifier.strip() for identifier in active_tunnels if identifier.strip()}
+        for tunnel_id, tunnel in session.tunnels.items():
+            if tunnel.state == TunnelState.CLOSED:
+                continue
+            if tunnel_id in active:
+                if tunnel.state != TunnelState.ACTIVE:
+                    tunnel.state = TunnelState.ACTIVE
+                tunnel.updated_at = timestamp
+            else:
+                if tunnel.state != TunnelState.PENDING:
+                    tunnel.state = TunnelState.PENDING
+                    tunnel.updated_at = timestamp
+
+    def _prune_expired_locked(self) -> None:
+        now = _utcnow()
+        expired = [
+            agent_id
+            for agent_id, session in self._sessions.items()
+            if session.expires_at(self._session_timeout) <= now
+        ]
+        for agent_id in expired:
+            self._sessions.pop(agent_id, None)
+
+
+__all__ = [
+    "AgentRegistry",
+    "AgentSession",
+    "DEFAULT_SESSION_TIMEOUT",
+    "DEFAULT_TUNNEL_HOST",
+    "DEFAULT_TUNNEL_PORT",
+    "Tunnel",
+    "TunnelState",
+]

--- a/app/service.py
+++ b/app/service.py
@@ -1,0 +1,399 @@
+"""HTTP API for coordinating agents and hypervisor management tunnels."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from pydantic import BaseModel, Field
+
+from .agents import (
+    AgentRegistry,
+    AgentSession,
+    DEFAULT_TUNNEL_HOST,
+    DEFAULT_TUNNEL_PORT,
+    Tunnel,
+)
+from .database import Database, resolve_database_path
+from .models import User
+
+logger = logging.getLogger("playrservers.service")
+
+
+class TunnelEndpoint(BaseModel):
+    host: str = Field(..., description="Hostname clients should connect to")
+    port: int = Field(..., description="Port exposed for tunnel traffic")
+
+
+class AgentConnectRequest(BaseModel):
+    agent_id: str = Field(..., min_length=1, max_length=128)
+    hostname: str = Field(..., min_length=1, max_length=255)
+    capabilities: List[str] = Field(default_factory=list)
+    metadata: Dict[str, str] = Field(default_factory=dict)
+
+
+class AgentConnectResponse(BaseModel):
+    agent_id: str
+    session_id: str
+    agent_token: str
+    hostname: str
+    capabilities: List[str]
+    metadata: Dict[str, str]
+    tunnel_endpoint: TunnelEndpoint
+    connected_at: datetime
+    expires_at: datetime
+
+
+class AgentHeartbeatRequest(BaseModel):
+    session_id: str
+    agent_token: str
+    active_tunnels: Optional[List[str]] = None
+
+
+class TunnelHeartbeatEntry(BaseModel):
+    tunnel_id: str
+    state: str
+    purpose: str
+    remote_port: int
+
+
+class AgentHeartbeatResponse(BaseModel):
+    agent_id: str
+    session_id: str
+    last_seen: datetime
+    expires_at: datetime
+    tunnels: List[TunnelHeartbeatEntry]
+
+
+class TunnelCreateRequest(BaseModel):
+    session_id: str
+    agent_token: str
+    purpose: str = Field(..., min_length=1, max_length=32)
+    remote_port: int = Field(..., ge=1, le=65535)
+    description: Optional[str] = Field(default=None, max_length=512)
+    metadata: Dict[str, str] = Field(default_factory=dict)
+
+
+class TunnelCloseRequest(BaseModel):
+    session_id: str
+    agent_token: str
+
+
+class TunnelView(BaseModel):
+    tunnel_id: str
+    state: str
+    purpose: str
+    remote_port: int
+    client_token: str
+    endpoint: TunnelEndpoint
+    created_at: datetime
+    updated_at: datetime
+    description: Optional[str] = None
+    metadata: Dict[str, str] = Field(default_factory=dict)
+
+
+class TunnelCreateResponse(TunnelView):
+    agent_id: str
+    session_id: str
+
+
+class TunnelCloseResponse(TunnelView):
+    agent_id: str
+    session_id: str
+
+
+class TunnelListResponse(BaseModel):
+    agent_id: str
+    tunnels: List[TunnelView]
+
+
+class AgentStatusResponse(BaseModel):
+    agent_id: str
+    session_id: str
+    hostname: str
+    capabilities: List[str]
+    metadata: Dict[str, str]
+    connected_at: datetime
+    last_seen: datetime
+    expires_at: datetime
+    tunnel_endpoint: TunnelEndpoint
+    tunnels: List[TunnelView]
+
+
+def _tunnel_to_view(tunnel: Tunnel, registry: AgentRegistry) -> TunnelView:
+    return TunnelView(
+        tunnel_id=tunnel.id,
+        state=tunnel.state.value,
+        purpose=tunnel.purpose,
+        remote_port=tunnel.remote_port,
+        client_token=tunnel.token,
+        endpoint=TunnelEndpoint(host=registry.tunnel_host, port=registry.tunnel_port),
+        created_at=tunnel.created_at,
+        updated_at=tunnel.updated_at,
+        description=tunnel.description,
+        metadata=dict(tunnel.metadata),
+    )
+
+
+def _session_to_status(session: AgentSession, registry: AgentRegistry) -> AgentStatusResponse:
+    return AgentStatusResponse(
+        agent_id=session.agent_id,
+        session_id=session.session_id,
+        hostname=session.hostname,
+        capabilities=list(session.capabilities),
+        metadata=dict(session.metadata),
+        connected_at=session.created_at,
+        last_seen=session.last_seen,
+        expires_at=session.expires_at(registry.session_timeout),
+        tunnel_endpoint=TunnelEndpoint(host=registry.tunnel_host, port=registry.tunnel_port),
+        tunnels=[_tunnel_to_view(tunnel, registry) for tunnel in session.tunnels.values()],
+    )
+
+
+def _heartbeat_to_response(session: AgentSession, registry: AgentRegistry) -> AgentHeartbeatResponse:
+    return AgentHeartbeatResponse(
+        agent_id=session.agent_id,
+        session_id=session.session_id,
+        last_seen=session.last_seen,
+        expires_at=session.expires_at(registry.session_timeout),
+        tunnels=[
+            TunnelHeartbeatEntry(
+                tunnel_id=tunnel.id,
+                state=tunnel.state.value,
+                purpose=tunnel.purpose,
+                remote_port=tunnel.remote_port,
+            )
+            for tunnel in session.tunnels.values()
+        ],
+    )
+
+
+def _initialise_database(database: Database) -> Database:
+    database.initialize()
+    return database
+
+
+def _build_auth_dependency(database: Database):
+    security = HTTPBasic()
+
+    def dependency(credentials: HTTPBasicCredentials = Depends(security)) -> User:
+        user = database.authenticate_user(credentials.username, credentials.password)
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication credentials",
+                headers={"WWW-Authenticate": "Basic"},
+            )
+        return user
+
+    return dependency
+
+
+def create_app(
+    *,
+    database: Database | None = None,
+    registry: AgentRegistry | None = None,
+    tunnel_host: str | None = None,
+    tunnel_port: int | None = None,
+) -> FastAPI:
+    """Instantiate the FastAPI application for the management plane."""
+
+    db = database or Database(resolve_database_path(os.getenv("MANAGEMENT_DB_PATH")))
+    _initialise_database(db)
+
+    app_registry = registry or AgentRegistry(
+        tunnel_host=tunnel_host or DEFAULT_TUNNEL_HOST,
+        tunnel_port=tunnel_port or DEFAULT_TUNNEL_PORT,
+    )
+
+    app = FastAPI(
+        title="PlayrServers Management API",
+        version="0.1.0",
+        description="Control plane for authenticated hypervisor management tunnels.",
+    )
+
+    current_user = _build_auth_dependency(db)
+
+    @app.get("/healthz")
+    async def healthcheck() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/v1/agents/connect", response_model=AgentConnectResponse)
+    async def connect_agent(
+        request: AgentConnectRequest,
+        user: User = Depends(current_user),
+    ) -> AgentConnectResponse:
+        try:
+            session = await app_registry.connect_agent(
+                agent_id=request.agent_id,
+                user_id=user.id,
+                hostname=request.hostname,
+                capabilities=request.capabilities,
+                metadata=request.metadata,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        except PermissionError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+
+        logger.info("Agent %s connected for user %s", session.agent_id, user.id)
+
+        return AgentConnectResponse(
+            agent_id=session.agent_id,
+            session_id=session.session_id,
+            agent_token=session.token,
+            hostname=session.hostname,
+            capabilities=list(session.capabilities),
+            metadata=dict(session.metadata),
+            tunnel_endpoint=TunnelEndpoint(
+                host=app_registry.tunnel_host,
+                port=app_registry.tunnel_port,
+            ),
+            connected_at=session.created_at,
+            expires_at=session.expires_at(app_registry.session_timeout),
+        )
+
+    @app.post("/v1/agents/{agent_id}/heartbeat", response_model=AgentHeartbeatResponse)
+    async def heartbeat(
+        agent_id: str,
+        request: AgentHeartbeatRequest,
+        user: User = Depends(current_user),
+    ) -> AgentHeartbeatResponse:
+        try:
+            session = await app_registry.heartbeat(
+                agent_id=agent_id,
+                user_id=user.id,
+                session_id=request.session_id,
+                token=request.agent_token,
+                active_tunnels=request.active_tunnels,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+        except PermissionError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        except KeyError:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+        return _heartbeat_to_response(session, app_registry)
+
+    @app.post(
+        "/v1/agents/{agent_id}/tunnels",
+        status_code=status.HTTP_201_CREATED,
+        response_model=TunnelCreateResponse,
+    )
+    async def create_tunnel(
+        agent_id: str,
+        request: TunnelCreateRequest,
+        user: User = Depends(current_user),
+    ) -> TunnelCreateResponse:
+        try:
+            tunnel, session = await app_registry.create_tunnel(
+                agent_id=agent_id,
+                user_id=user.id,
+                session_id=request.session_id,
+                token=request.agent_token,
+                purpose=request.purpose,
+                remote_port=request.remote_port,
+                description=request.description,
+                metadata=request.metadata,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        except PermissionError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+        return TunnelCreateResponse(
+            agent_id=session.agent_id,
+            session_id=session.session_id,
+            tunnel_id=tunnel.id,
+            state=tunnel.state.value,
+            purpose=tunnel.purpose,
+            remote_port=tunnel.remote_port,
+            client_token=tunnel.token,
+            endpoint=TunnelEndpoint(
+                host=app_registry.tunnel_host,
+                port=app_registry.tunnel_port,
+            ),
+            created_at=tunnel.created_at,
+            updated_at=tunnel.updated_at,
+            description=tunnel.description,
+            metadata=dict(tunnel.metadata),
+        )
+
+    @app.post(
+        "/v1/agents/{agent_id}/tunnels/{tunnel_id}/close",
+        response_model=TunnelCloseResponse,
+    )
+    async def close_tunnel(
+        agent_id: str,
+        tunnel_id: str,
+        request: TunnelCloseRequest,
+        user: User = Depends(current_user),
+    ) -> TunnelCloseResponse:
+        try:
+            tunnel, session = await app_registry.close_tunnel(
+                agent_id=agent_id,
+                user_id=user.id,
+                session_id=request.session_id,
+                token=request.agent_token,
+                tunnel_id=tunnel_id,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        except PermissionError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+        return TunnelCloseResponse(
+            agent_id=session.agent_id,
+            session_id=session.session_id,
+            tunnel_id=tunnel.id,
+            state=tunnel.state.value,
+            purpose=tunnel.purpose,
+            remote_port=tunnel.remote_port,
+            client_token=tunnel.token,
+            endpoint=TunnelEndpoint(
+                host=app_registry.tunnel_host,
+                port=app_registry.tunnel_port,
+            ),
+            created_at=tunnel.created_at,
+            updated_at=tunnel.updated_at,
+            description=tunnel.description,
+            metadata=dict(tunnel.metadata),
+        )
+
+    @app.get("/v1/agents/{agent_id}", response_model=AgentStatusResponse)
+    async def get_agent(agent_id: str, user: User = Depends(current_user)) -> AgentStatusResponse:
+        try:
+            session = await app_registry.get_session(agent_id=agent_id, user_id=user.id)
+        except PermissionError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        except KeyError:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+        return _session_to_status(session, app_registry)
+
+    @app.get("/v1/agents/{agent_id}/tunnels", response_model=TunnelListResponse)
+    async def list_tunnels(agent_id: str, user: User = Depends(current_user)) -> TunnelListResponse:
+        try:
+            session = await app_registry.get_session(agent_id=agent_id, user_id=user.id)
+        except PermissionError as exc:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+        except KeyError:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+        return TunnelListResponse(
+            agent_id=session.agent_id,
+            tunnels=[_tunnel_to_view(tunnel, app_registry) for tunnel in session.tunnels.values()],
+        )
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/main.py
+++ b/main.py
@@ -1,28 +1,88 @@
-"""Utility entry point for preparing the management database."""
+"""Command-line interface for the PlayrServers management service."""
 
 from __future__ import annotations
 
+import argparse
 import logging
 import os
+from typing import Sequence
 
 from app.database import Database, resolve_database_path
 
 logger = logging.getLogger("playrservers.main")
 
 
-def main() -> None:
-    """Initialise the SQLite database and exit."""
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="PlayrServers management utilities")
+    subparsers = parser.add_subparsers(dest="command")
+
+    parser.set_defaults(command="init-db")
+
+    subparsers.add_parser("init-db", help="Initialise the management database")
+
+    serve_parser = subparsers.add_parser("serve", help="Start the HTTP management service")
+    serve_parser.add_argument("--host", default="0.0.0.0", help="Bind address for the API")
+    serve_parser.add_argument("--port", type=int, default=8000, help="Port for the API")
+    serve_parser.add_argument(
+        "--tunnel-host",
+        default=None,
+        help="Override the public hostname advertised to agents",
+    )
+    serve_parser.add_argument(
+        "--tunnel-port",
+        type=int,
+        default=None,
+        help="Override the public port advertised to agents",
+    )
+
+    return parser.parse_args(argv)
+
+
+def _initialise_database() -> Database:
+    db_path = resolve_database_path(os.getenv("MANAGEMENT_DB_PATH"))
+    database = Database(db_path)
+    database.initialize()
+    logger.info("Database initialised at %s", db_path)
+    return database
+
+
+def _serve(
+    *,
+    database: Database,
+    host: str,
+    port: int,
+    tunnel_host: str | None,
+    tunnel_port: int | None,
+) -> None:
+    from app.service import create_app
+    import uvicorn
+
+    logger.info("Starting management API on %s:%s", host, port)
+
+    app = create_app(
+        database=database,
+        tunnel_host=tunnel_host,
+        tunnel_port=tunnel_port,
+    )
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Entry point for CLI usage."""
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 
-    db_path = resolve_database_path(os.getenv("MANAGEMENT_DB_PATH"))
-    Database(db_path).initialize()
-    logger.info("Database initialised at %s", db_path)
+    args = _parse_args(argv)
+    database = _initialise_database()
 
-    logger.warning(
-        "The HTTP API and management interface have been removed. "
-        "This command now only prepares the database for future development."
-    )
+    if args.command == "serve":
+        _serve(
+            database=database,
+            host=args.host,
+            port=args.port,
+            tunnel_host=args.tunnel_host,
+            tunnel_port=args.tunnel_port,
+        )
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-# No runtime dependencies are required for the stripped-down codebase yet.
+fastapi>=0.110
+uvicorn>=0.22
+httpx>=0.24

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,166 @@
+"""End-to-end tests for the management service HTTP API."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.agents import AgentRegistry
+from app.database import Database
+from app.service import create_app
+
+
+class ManagementServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        db_path = Path(self._tempdir.name) / "management.sqlite3"
+        self.database = Database(db_path)
+        self.database.initialize()
+        self.user_email = "alice@example.com"
+        self.user_password = "SuperSecret123!"
+        self.user = self.database.create_user("Alice", self.user_email, self.user_password)
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def _auth(self) -> tuple[str, str]:
+        email = self.user.email or self.user_email
+        return email, self.user_password
+
+    def test_agent_connection_and_tunnel_lifecycle(self) -> None:
+        registry = AgentRegistry()
+        app = create_app(database=self.database, registry=registry)
+
+        with TestClient(app) as client:
+            connect = client.post(
+                "/v1/agents/connect",
+                auth=self._auth(),
+                json={
+                    "agent_id": "agent-01",
+                    "hostname": "hypervisor01",
+                    "capabilities": ["ssh", "metrics"],
+                },
+            )
+            self.assertEqual(connect.status_code, 200, connect.text)
+            payload = connect.json()
+            self.assertIn("session_id", payload)
+            self.assertIn("agent_token", payload)
+            self.assertEqual(payload["tunnel_endpoint"], {"host": "manage.playrservers.com", "port": 443})
+
+            session_id = payload["session_id"]
+            agent_token = payload["agent_token"]
+
+            heartbeat = client.post(
+                "/v1/agents/agent-01/heartbeat",
+                auth=self._auth(),
+                json={
+                    "session_id": session_id,
+                    "agent_token": agent_token,
+                },
+            )
+            self.assertEqual(heartbeat.status_code, 200, heartbeat.text)
+            heartbeat_payload = heartbeat.json()
+            self.assertEqual(heartbeat_payload["agent_id"], "agent-01")
+
+            created = client.post(
+                "/v1/agents/agent-01/tunnels",
+                auth=self._auth(),
+                json={
+                    "session_id": session_id,
+                    "agent_token": agent_token,
+                    "purpose": "ssh",
+                    "remote_port": 22,
+                },
+            )
+            self.assertEqual(created.status_code, 201, created.text)
+            tunnel_info = created.json()
+            self.assertEqual(tunnel_info["endpoint"], {"host": "manage.playrservers.com", "port": 443})
+            tunnel_id = tunnel_info["tunnel_id"]
+
+            status = client.get("/v1/agents/agent-01", auth=self._auth())
+            self.assertEqual(status.status_code, 200, status.text)
+            status_payload = status.json()
+            self.assertEqual(len(status_payload["tunnels"]), 1)
+            self.assertEqual(status_payload["tunnels"][0]["tunnel_id"], tunnel_id)
+
+            listing = client.get("/v1/agents/agent-01/tunnels", auth=self._auth())
+            self.assertEqual(listing.status_code, 200, listing.text)
+            listing_payload = listing.json()
+            self.assertEqual(len(listing_payload["tunnels"]), 1)
+
+            closed = client.post(
+                f"/v1/agents/agent-01/tunnels/{tunnel_id}/close",
+                auth=self._auth(),
+                json={
+                    "session_id": session_id,
+                    "agent_token": agent_token,
+                },
+            )
+            self.assertEqual(closed.status_code, 200, closed.text)
+            closed_payload = closed.json()
+            self.assertEqual(closed_payload["state"], "closed")
+
+    def test_agent_cannot_be_claimed_by_other_user(self) -> None:
+        other = self.database.create_user("Bob", "bob@example.com", "Password456?")
+
+        registry = AgentRegistry()
+        app = create_app(database=self.database, registry=registry)
+
+        with TestClient(app) as client:
+            first = client.post(
+                "/v1/agents/connect",
+                auth=self._auth(),
+                json={"agent_id": "duplicate", "hostname": "node-a"},
+            )
+            self.assertEqual(first.status_code, 200, first.text)
+
+            second = client.post(
+                "/v1/agents/connect",
+                auth=(other.email or "", "Password456?"),
+                json={"agent_id": "duplicate", "hostname": "node-b"},
+            )
+            self.assertEqual(second.status_code, 403, second.text)
+
+    def test_heartbeat_rejects_invalid_session(self) -> None:
+        registry = AgentRegistry()
+        app = create_app(database=self.database, registry=registry)
+
+        with TestClient(app) as client:
+            connect = client.post(
+                "/v1/agents/connect",
+                auth=self._auth(),
+                json={"agent_id": "agent-02", "hostname": "hypervisor02"},
+            )
+            self.assertEqual(connect.status_code, 200, connect.text)
+            payload = connect.json()
+
+            bad_heartbeat = client.post(
+                "/v1/agents/agent-02/heartbeat",
+                auth=self._auth(),
+                json={
+                    "session_id": payload["session_id"],
+                    "agent_token": "not-the-right-token",
+                },
+            )
+            self.assertEqual(bad_heartbeat.status_code, 401, bad_heartbeat.text)
+
+    def test_custom_tunnel_endpoint_can_be_overridden(self) -> None:
+        registry = AgentRegistry(tunnel_host="staging.playrservers.com", tunnel_port=8443)
+        app = create_app(database=self.database, registry=registry)
+
+        with TestClient(app) as client:
+            connect = client.post(
+                "/v1/agents/connect",
+                auth=self._auth(),
+                json={"agent_id": "agent-03", "hostname": "hypervisor03"},
+            )
+            self.assertEqual(connect.status_code, 200, connect.text)
+            payload = connect.json()
+            self.assertEqual(payload["tunnel_endpoint"], {"host": "staging.playrservers.com", "port": 8443})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce an in-memory agent registry and tunnel lifecycle management helpers
- expose a FastAPI application with authenticated endpoints for agent connectivity and tunnel orchestration
- update the CLI, documentation, and dependencies to run the new management service alongside a test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf044a7a8483318f2bde6fcc64fea9