### PR TITLE
Add non-interactive installer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ python scripts/install_service.py
 Use `--skip-deps` if you prefer to manage Python packages yourself. When the
 script completes you can start the API with `python main.py serve`.
 
+To run the installer without interactive prompts, provide the initial account
+details via flags:
+
+```bash
+python scripts/install_service.py \
+  --admin-name "Service Admin" \
+  --admin-email admin@example.com \
+  --admin-password "your-strong-password"
+```
+
+All three options must be supplied together, and the password must be at least
+12 characters long.
+
 ### Manual setup
 
 Create a virtual environment and install the web-service dependencies:

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -1,0 +1,53 @@
+"""Tests for the non-interactive installer helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.database import Database
+from scripts.install_service import create_initial_user
+
+
+def _initialised_database(tmp_path):
+    db_path = tmp_path / "installer.sqlite3"
+    database = Database(db_path)
+    database.initialize()
+    return database
+
+
+def test_create_initial_user_cli_arguments(tmp_path):
+    database = _initialised_database(tmp_path)
+
+    create_initial_user(
+        database,
+        admin_name="Service Admin",
+        admin_email="ADMIN@example.com",
+        admin_password="supersecurepw",
+    )
+
+    stored = database.get_user_by_email("admin@example.com")
+    assert stored is not None
+    assert stored.name == "Service Admin"
+
+
+def test_create_initial_user_cli_missing_field(tmp_path):
+    database = _initialised_database(tmp_path)
+
+    with pytest.raises(ValueError):
+        create_initial_user(
+            database,
+            admin_name="Service Admin",
+            admin_password="anothersecurepw",
+        )
+
+
+def test_create_initial_user_cli_short_password(tmp_path):
+    database = _initialised_database(tmp_path)
+
+    with pytest.raises(ValueError):
+        create_initial_user(
+            database,
+            admin_name="Service Admin",
+            admin_email="admin@example.com",
+            admin_password="short",
+        )


### PR DESCRIPTION
## Summary
- add CLI flags to the installer for providing the initial admin user non-interactively
- document the new flags in the README and cover them with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0a0c2650833197f9b89973ae9552