### PR TITLE
Add secure web dashboard and HTTPS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ clean foundation.
 - ✅ **Agent coordination service** – `app.service.create_app()` exposes a
   FastAPI application that agents use to authenticate, maintain heartbeats, and
   request encrypted tunnels that terminate on `manage.playrservers.com:443`.
+- ✅ **Secure web dashboard** – administrators can sign in at
+  `https://<host>/` to review their account and view paired hypervisors.
 - ✅ **Command-line bootstrap** – `python main.py` initialises the database by
   default, while `python main.py serve` launches the HTTP control plane.
 
@@ -84,11 +86,22 @@ python scripts/create_user.py "Test User" test@example.com
 
 ### Running the management API
 
-Launch the API using the same credentials you created above:
+Launch the API using the same credentials you created above. Provide the path to
+your TLS certificate and private key so the management portal is available over
+HTTPS on port 443:
 
 ```bash
-python main.py serve --host 0.0.0.0 --port 8000
+python main.py serve \
+  --host 0.0.0.0 \
+  --port 443 \
+  --ssl-certfile /etc/ssl/certs/management.crt \
+  --ssl-keyfile /etc/ssl/private/management.key
 ```
+
+With the service running you can sign in at `https://localhost/` (or the
+appropriate hostname) to access the new management dashboard. Sessions are
+kept in-memory on the server, so restarting the process will invalidate any
+active browser logins.
 
 Agents authenticate with HTTP Basic credentials (email + password) and interact
 with the following key endpoints:

--- a/app/sessions.py
+++ b/app/sessions.py
@@ -1,0 +1,61 @@
+"""In-memory session handling for the management web interface."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+
+@dataclass
+class _SessionRecord:
+    user_id: int
+    expires_at: datetime
+
+
+class SessionManager:
+    """Generate, validate, and revoke web dashboard sessions."""
+
+    def __init__(self, *, ttl: timedelta = timedelta(hours=8)) -> None:
+        self._ttl = ttl
+        self._sessions: Dict[str, _SessionRecord] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def ttl(self) -> timedelta:
+        return self._ttl
+
+    @property
+    def cookie_max_age(self) -> int:
+        return int(self._ttl.total_seconds())
+
+    def create(self, user_id: int) -> str:
+        token = secrets.token_urlsafe(32)
+        record = _SessionRecord(user_id=user_id, expires_at=self._now() + self._ttl)
+        with self._lock:
+            self._sessions[token] = record
+        return token
+
+    def resolve(self, token: str) -> Optional[int]:
+        now = self._now()
+        with self._lock:
+            record = self._sessions.get(token)
+            if record is None:
+                return None
+            if record.expires_at <= now:
+                self._sessions.pop(token, None)
+                return None
+            record.expires_at = now + self._ttl
+            return record.user_id
+
+    def destroy(self, token: str) -> None:
+        with self._lock:
+            self._sessions.pop(token, None)
+
+    def _now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+__all__ = ["SessionManager"]

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1,0 +1,298 @@
+:root {
+  color-scheme: light dark;
+  --surface: #ffffff;
+  --surface-muted: #f4f6fb;
+  --surface-border: #d6d9e5;
+  --text-primary: #0f172a;
+  --text-muted: #475569;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --danger: #dc2626;
+  --success: #16a34a;
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+  color: var(--text-primary);
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem clamp(1rem, 4vw, 3rem);
+  background: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.18);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(16px);
+}
+
+.navbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  font-size: 1.1rem;
+  letter-spacing: 0.01em;
+}
+
+.navbar__logo {
+  font-size: 1.5rem;
+}
+
+.navbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.navbar__user {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.nav-link {
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+
+.nav-link:hover,
+.nav-link--active {
+  color: #fff;
+}
+
+.nav-link--active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.4rem;
+  height: 2px;
+  background: #60a5fa;
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw, 3.5rem) clamp(1rem, 4vw, 3rem) 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.card--centered {
+  max-width: 420px;
+  margin: 3rem auto;
+  text-align: left;
+}
+
+.card__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.card__subtitle {
+  margin: 0 0 1.5rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.form__input {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--surface-border);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form__input:focus {
+  outline: none;
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.2);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  padding: 0.8rem 1.6rem;
+  font-size: 1rem;
+  border-radius: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button--primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.25);
+}
+
+.button--primary:hover {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+}
+
+.alert {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+
+.alert--error {
+  background: rgba(220, 38, 38, 0.08);
+  color: #991b1b;
+  border: 1px solid rgba(220, 38, 38, 0.2);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  margin: 1.5rem 0 0;
+  padding: 0;
+}
+
+.detail-grid__item dt {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+}
+
+.detail-grid__item dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.table {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.table__header,
+.table__row {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: var(--surface-muted);
+}
+
+.table__header {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.table__row {
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.table__row:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+}
+
+.table__cell--emphasis {
+  font-weight: 600;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.25);
+  color: var(--text-muted);
+}
+
+.status-pill--success {
+  background: rgba(22, 163, 74, 0.12);
+  color: var(--success);
+}
+
+.status-pill--muted {
+  background: rgba(100, 116, 139, 0.18);
+}
+
+.text-muted {
+  color: var(--text-muted);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  background: var(--surface-muted);
+  border-radius: 18px;
+  border: 1px dashed rgba(148, 163, 184, 0.5);
+}
+
+.empty-state h2 {
+  margin-bottom: 0.75rem;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+  .table__header,
+  .table__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .table__header span:nth-child(n + 3),
+  .table__row span:nth-child(n + 3) {
+    display: block;
+  }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}PlayrServers Management{% endblock %}</title>
+    <link rel="stylesheet" href="{{ request.url_for('static', path='css/app.css') }}" />
+  </head>
+  <body>
+    <header class="navbar">
+      <div class="navbar__brand">
+        <span class="navbar__logo" aria-hidden="true">⛅</span>
+        <span>PlayrServers Management</span>
+      </div>
+      {% if user %}
+      <nav class="navbar__actions" aria-label="Primary">
+        <a href="{{ request.url_for('ui_dashboard') }}" class="nav-link{% if request.url.path == request.url_for('ui_dashboard') %} nav-link--active{% endif %}">Dashboard</a>
+        <a href="{{ request.url_for('ui_logout') }}" class="nav-link">Sign out</a>
+        <span class="navbar__user">{{ user.name }}</span>
+      </nav>
+      {% endif %}
+    </header>
+
+    <main class="page">
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="footer">
+      <p>© {{ now().year }} PlayrServers. Secure management for your infrastructure.</p>
+    </footer>
+  </body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard · PlayrServers Management{% endblock %}
+
+{% block content %}
+<section class="card">
+  <h1 class="card__title">Account overview</h1>
+  <p class="card__subtitle">Review the details associated with your management account.</p>
+  <dl class="detail-grid">
+    <div class="detail-grid__item">
+      <dt>Name</dt>
+      <dd>{{ user.name }}</dd>
+    </div>
+    <div class="detail-grid__item">
+      <dt>Email</dt>
+      <dd>{{ user.email or 'Not set' }}</dd>
+    </div>
+    <div class="detail-grid__item">
+      <dt>Created</dt>
+      <dd>{{ format_datetime(user.created_at) }}</dd>
+    </div>
+    <div class="detail-grid__item">
+      <dt>Paired hypervisors</dt>
+      <dd>{{ hypervisor_count }}</dd>
+    </div>
+    <div class="detail-grid__item">
+      <dt>Online now</dt>
+      <dd>{{ online_count }}</dd>
+    </div>
+  </dl>
+</section>
+
+<section class="card">
+  <div class="card__title">Paired hypervisors</div>
+  <p class="card__subtitle">Hypervisors authenticate back to this control plane and surface secure tunnels.</p>
+
+  {% if hypervisors %}
+  <div class="table">
+    <div class="table__header">
+      <span>Agent</span>
+      <span>Hostname</span>
+      <span>Status</span>
+      <span>Capabilities</span>
+      <span>Last seen</span>
+      <span>Tunnels</span>
+    </div>
+    {% for hypervisor in hypervisors %}
+    <div class="table__row">
+      <span class="table__cell table__cell--emphasis">{{ hypervisor.agent_id }}</span>
+      <span class="table__cell">{{ hypervisor.hostname }}</span>
+      <span class="table__cell">
+        <span class="status-pill{% if hypervisor.is_online %} status-pill--success{% else %} status-pill--muted{% endif %}">
+          {{ 'Online' if hypervisor.is_online else 'Offline' }}
+        </span>
+      </span>
+      <span class="table__cell">
+        {% if hypervisor.capabilities %}
+          {{ hypervisor.capabilities | join(', ') }}
+        {% else %}
+          <span class="text-muted">None reported</span>
+        {% endif %}
+      </span>
+      <span class="table__cell">{{ format_datetime(hypervisor.last_seen) }}</span>
+      <span class="table__cell">
+        <strong>{{ hypervisor.active_tunnels }}</strong> active
+        {% if hypervisor.pending_tunnels %}
+          · {{ hypervisor.pending_tunnels }} pending
+        {% endif %}
+        {% if hypervisor.closed_tunnels %}
+          · {{ hypervisor.closed_tunnels }} closed
+        {% endif %}
+      </span>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="empty-state">
+    <h2>No hypervisors connected yet</h2>
+    <p>Install and pair a PlayrServers agent to begin managing your infrastructure from this dashboard.</p>
+  </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}Sign in · PlayrServers Management{% endblock %}
+
+{% block content %}
+<section class="card card--centered">
+  <h1 class="card__title">Welcome back</h1>
+  <p class="card__subtitle">
+    Sign in with your management credentials to access your account overview and paired hypervisors.
+  </p>
+  {% if error %}
+  <div class="alert alert--error">{{ error }}</div>
+  {% endif %}
+  <form method="post" action="{{ request.url_for('ui_login_submit') }}" class="form">
+    <label class="form__label" for="email">Email address</label>
+    <input
+      class="form__input"
+      type="email"
+      id="email"
+      name="email"
+      value="{{ email }}"
+      autocomplete="username"
+      required
+    />
+
+    <label class="form__label" for="password">Password</label>
+    <input
+      class="form__input"
+      type="password"
+      id="password"
+      name="password"
+      autocomplete="current-password"
+      required
+    />
+
+    <button type="submit" class="button button--primary">Sign in</button>
+  </form>
+</section>
+{% endblock %}

--- a/app/web.py
+++ b/app/web.py
@@ -1,0 +1,471 @@
+"""Web interface for the PlayrServers management control plane."""
+
+from __future__ import annotations
+
+import html
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Tuple
+
+from fastapi import APIRouter, FastAPI, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from .agents import AgentRegistry, AgentSession, Tunnel, TunnelState
+from .database import Database
+from .models import User
+from .sessions import SessionManager
+from urllib.parse import parse_qs
+
+logger = logging.getLogger("playrservers.web")
+
+SESSION_COOKIE_NAME = "psm_session"
+
+
+@dataclass(frozen=True)
+class HypervisorSummary:
+    """Presentation details for a paired hypervisor."""
+
+    agent_id: str
+    hostname: str
+    capabilities: tuple[str, ...]
+    metadata: Dict[str, str]
+    connected_at: datetime
+    last_seen: datetime
+    endpoint_host: str
+    endpoint_port: int
+    is_online: bool
+    active_tunnels: int
+    pending_tunnels: int
+    closed_tunnels: int
+
+
+def _template_environment() -> Jinja2Templates:
+    base_dir = Path(__file__).resolve().parent
+    templates = Jinja2Templates(directory=str(base_dir / "templates"))
+    return templates
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%d %b %Y • %H:%M %Z")
+
+
+def _tunnel_counters(tunnels: Iterable[Tunnel]) -> tuple[int, int, int]:
+    active = pending = closed = 0
+    for tunnel in tunnels:
+        if tunnel.state is TunnelState.ACTIVE:
+            active += 1
+        elif tunnel.state is TunnelState.CLOSED:
+            closed += 1
+        else:
+            pending += 1
+    return active, pending, closed
+
+
+def _session_to_summary(session: AgentSession, registry: AgentRegistry) -> HypervisorSummary:
+    expires_at = session.expires_at(registry.session_timeout)
+    now = datetime.now(timezone.utc)
+    is_online = expires_at > now
+    active, pending, closed = _tunnel_counters(session.tunnels.values())
+
+    return HypervisorSummary(
+        agent_id=session.agent_id,
+        hostname=session.hostname,
+        capabilities=session.capabilities,
+        metadata=dict(session.metadata),
+        connected_at=session.created_at,
+        last_seen=session.last_seen,
+        endpoint_host=registry.tunnel_host,
+        endpoint_port=registry.tunnel_port,
+        is_online=is_online,
+        active_tunnels=active,
+        pending_tunnels=pending,
+        closed_tunnels=closed,
+    )
+
+
+def register_ui_routes(
+    app: FastAPI,
+    database: Database,
+    registry: AgentRegistry,
+    *,
+    session_manager: SessionManager,
+    secure_cookies: bool,
+) -> None:
+    """Expose the HTML management interface on the provided FastAPI app."""
+
+    try:
+        templates = _template_environment()
+    except AssertionError:
+        logger.warning(
+            "jinja2 is not installed; falling back to a minimal HTML renderer for the"
+            " management dashboard."
+        )
+        templates = None
+    static_dir = Path(__file__).resolve().parent / "static"
+    if static_dir.exists():
+        app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    router = APIRouter(include_in_schema=False)
+
+    def _base_context(request: Request, user: Optional[User], **extra):
+        context = {
+            "request": request,
+            "user": user,
+            "format_datetime": _format_datetime,
+            "now": datetime.now,
+        }
+        context.update(extra)
+        return context
+
+    def _build_base_markup(
+        request: Request,
+        *,
+        user: Optional[User],
+        title: str,
+        stylesheet: str,
+        content: str,
+    ) -> str:
+        dashboard_url = request.url_for("ui_dashboard")
+        logout_url = request.url_for("ui_logout")
+        brand = "PlayrServers Management"
+        if user:
+            user_name = html.escape(user.name)
+            nav_actions = (
+                f'<nav class="navbar__actions" aria-label="Primary">'
+                f'<a href="{dashboard_url}" class="nav-link nav-link--active">Dashboard</a>'
+                f'<a href="{logout_url}" class="nav-link">Sign out</a>'
+                f'<span class="navbar__user">{user_name}</span>'
+                "</nav>"
+            )
+        else:
+            nav_actions = ""
+
+        year = datetime.now().year
+        navbar = (
+            f'<header class="navbar">'
+            f'<div class="navbar__brand"><span class="navbar__logo" aria-hidden="true">⛅</span><span>{brand}</span></div>'
+            f"{nav_actions}"
+            "</header>"
+        )
+
+        footer = (
+            f'<footer class="footer">© {year} PlayrServers. Secure management for your infrastructure.</footer>'
+        )
+
+        return (
+            "<!DOCTYPE html>\n"
+            "<html lang=\"en\">\n"
+            "  <head>\n"
+            "    <meta charset=\"utf-8\" />\n"
+            "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n"
+            f"    <title>{html.escape(title)}</title>\n"
+            f"    <link rel=\"stylesheet\" href=\"{stylesheet}\" />\n"
+            "  </head>\n"
+            "  <body>\n"
+            f"    {navbar}\n"
+            "    <main class=\"page\">\n"
+            f"{content}\n"
+            "    </main>\n"
+            f"    {footer}\n"
+            "  </body>\n"
+            "</html>"
+        )
+
+    def _render_login_markup(context: Dict[str, object], request: Request) -> str:
+        email = html.escape(str(context.get("email", "")))
+        error = context.get("error")
+        error_html = (
+            f'<div class="alert alert--error">{html.escape(str(error))}</div>'
+            if error
+            else ""
+        )
+        stylesheet = request.url_for("static", path="css/app.css")
+        body = f"""
+<section class="card card--centered">
+  <h1 class="card__title">Welcome back</h1>
+  <p class="card__subtitle">
+    Sign in with your management credentials to access your account overview and paired hypervisors.
+  </p>
+  {error_html}
+  <form method="post" action="{request.url_for('ui_login_submit')}" class="form">
+    <label class="form__label" for="email">Email address</label>
+    <input class="form__input" type="email" id="email" name="email" value="{email}" autocomplete="username" required />
+    <label class="form__label" for="password">Password</label>
+    <input class="form__input" type="password" id="password" name="password" autocomplete="current-password" required />
+    <button type="submit" class="button button--primary">Sign in</button>
+  </form>
+</section>
+"""
+        return _build_base_markup(
+            request,
+            user=None,
+            title="Sign in · PlayrServers Management",
+            stylesheet=str(stylesheet),
+            content=body,
+        )
+
+    def _render_dashboard_markup(context: Dict[str, object], request: Request) -> str:
+        user = context.get("user")
+        assert isinstance(user, User)
+        hypervisors = context.get("hypervisors", [])
+        assert isinstance(hypervisors, list)
+        hypervisor_count = int(context.get("hypervisor_count", 0))
+        online_count = int(context.get("online_count", 0))
+        stylesheet = request.url_for("static", path="css/app.css")
+
+        account_details = f"""
+<section class="card">
+  <h1 class="card__title">Account overview</h1>
+  <p class="card__subtitle">Review the details associated with your management account.</p>
+  <dl class="detail-grid">
+    <div class="detail-grid__item"><dt>Name</dt><dd>{html.escape(user.name)}</dd></div>
+    <div class="detail-grid__item"><dt>Email</dt><dd>{html.escape(user.email) if user.email else 'Not set'}</dd></div>
+    <div class="detail-grid__item"><dt>Created</dt><dd>{html.escape(_format_datetime(user.created_at))}</dd></div>
+    <div class="detail-grid__item"><dt>Paired hypervisors</dt><dd>{hypervisor_count}</dd></div>
+    <div class="detail-grid__item"><dt>Online now</dt><dd>{online_count}</dd></div>
+  </dl>
+</section>
+"""
+
+        rows = []
+        for summary in hypervisors:
+            if not isinstance(summary, HypervisorSummary):
+                continue
+            capabilities = ", ".join(html.escape(cap) for cap in summary.capabilities)
+            if capabilities:
+                capabilities_html = capabilities
+            else:
+                capabilities_html = '<span class="text-muted">None reported</span>'
+            status_class = "status-pill status-pill--success" if summary.is_online else "status-pill status-pill--muted"
+            status_label = "Online" if summary.is_online else "Offline"
+            tunnel_parts = [f"<strong>{summary.active_tunnels}</strong> active"]
+            if summary.pending_tunnels:
+                tunnel_parts.append(f"{summary.pending_tunnels} pending")
+            if summary.closed_tunnels:
+                tunnel_parts.append(f"{summary.closed_tunnels} closed")
+            tunnels_text = " · ".join(tunnel_parts)
+            rows.append(
+                """
+    <div class="table__row">
+      <span class="table__cell table__cell--emphasis">{agent}</span>
+      <span class="table__cell">{hostname}</span>
+      <span class="table__cell"><span class="{status_class}">{status_label}</span></span>
+      <span class="table__cell">{capabilities}</span>
+      <span class="table__cell">{last_seen}</span>
+      <span class="table__cell">{tunnels}</span>
+    </div>
+""".format(
+                    agent=html.escape(summary.agent_id),
+                    hostname=html.escape(summary.hostname),
+                    status_class=status_class,
+                    status_label=status_label,
+                    capabilities=capabilities_html,
+                    last_seen=html.escape(_format_datetime(summary.last_seen)),
+                    tunnels=tunnels_text,
+                )
+            )
+
+        if rows:
+            table_body = "\n".join(rows)
+            hypervisor_section = f"""
+<section class="card">
+  <div class="card__title">Paired hypervisors</div>
+  <p class="card__subtitle">Hypervisors authenticate back to this control plane and surface secure tunnels.</p>
+  <div class="table">
+    <div class="table__header">
+      <span>Agent</span>
+      <span>Hostname</span>
+      <span>Status</span>
+      <span>Capabilities</span>
+      <span>Last seen</span>
+      <span>Tunnels</span>
+    </div>
+{table_body}
+  </div>
+</section>
+"""
+        else:
+            hypervisor_section = """
+<section class="card">
+  <div class="card__title">Paired hypervisors</div>
+  <p class="card__subtitle">Hypervisors authenticate back to this control plane and surface secure tunnels.</p>
+  <div class="empty-state">
+    <h2>No hypervisors connected yet</h2>
+    <p>Install and pair a PlayrServers agent to begin managing your infrastructure from this dashboard.</p>
+  </div>
+</section>
+"""
+
+        body = account_details + hypervisor_section
+        return _build_base_markup(
+            request,
+            user=user,
+            title="Dashboard · PlayrServers Management",
+            stylesheet=str(stylesheet),
+            content=body,
+        )
+
+    def _render_login_response(
+        request: Request, context: Dict[str, object], *, status_code: int
+    ) -> HTMLResponse:
+        if templates is not None:
+            return templates.TemplateResponse("login.html", context, status_code=status_code)
+        markup = _render_login_markup(context, request)
+        return HTMLResponse(markup, status_code=status_code)
+
+    def _render_dashboard_response(request: Request, context: Dict[str, object]) -> HTMLResponse:
+        if templates is not None:
+            return templates.TemplateResponse("dashboard.html", context)
+        markup = _render_dashboard_markup(context, request)
+        return HTMLResponse(markup)
+
+    async def _parse_login_form(request: Request) -> Tuple[str, str]:
+        body_bytes = await request.body()
+        content_type = request.headers.get("content-type", "")
+        charset = "utf-8"
+        if "charset=" in content_type:
+            charset = content_type.split("charset=", 1)[1].split(";", 1)[0].strip() or "utf-8"
+        try:
+            decoded = body_bytes.decode(charset)
+        except (LookupError, UnicodeDecodeError):
+            decoded = body_bytes.decode("utf-8", errors="ignore")
+        data = parse_qs(decoded, keep_blank_values=True)
+        email = data.get("email", [""])[0]
+        password = data.get("password", [""])[0]
+        return email, password
+
+    def _load_user(request: Request) -> Tuple[Optional[User], Optional[str]]:
+        token = request.cookies.get(SESSION_COOKIE_NAME)
+        if not token:
+            return None, None
+        user_id = session_manager.resolve(token)
+        if user_id is None:
+            return None, token
+        user = database.get_user(user_id)
+        if user is None:
+            session_manager.destroy(token)
+            return None, token
+        return user, token
+
+    def _clear_session_cookie(response, token: Optional[str]) -> None:
+        if token:
+            session_manager.destroy(token)
+        response.delete_cookie(SESSION_COOKIE_NAME, path="/")
+
+    def _issue_session_cookie(response, token: str) -> None:
+        response.set_cookie(
+            SESSION_COOKIE_NAME,
+            token,
+            max_age=session_manager.cookie_max_age,
+            secure=secure_cookies,
+            httponly=True,
+            samesite="lax",
+            path="/",
+        )
+
+    def _render_login(
+        request: Request,
+        *,
+        email: str = "",
+        error: str | None = None,
+        status_code: int = status.HTTP_200_OK,
+    ):
+        user, token = _load_user(request)
+        if user is not None and token:
+            response = RedirectResponse(
+                request.url_for("ui_dashboard"), status_code=status.HTTP_303_SEE_OTHER
+            )
+            _issue_session_cookie(response, token)
+            return response
+
+        context = _base_context(request, None, email=email, error=error)
+        response = _render_login_response(request, context, status_code=status_code)
+        if token:
+            _clear_session_cookie(response, token)
+        return response
+
+    @router.get("/", response_class=HTMLResponse, name="ui_home")
+    async def homepage(request: Request):
+        return _render_login(request)
+
+    @router.get("/login", response_class=HTMLResponse, name="ui_login")
+    async def login_form(request: Request):
+        return _render_login(request)
+
+    @router.post("/login", name="ui_login_submit")
+    async def login_submit(request: Request):
+        email, password = await _parse_login_form(request)
+        if not email or not password:
+            return _render_login(
+                request,
+                email=email,
+                error="Please provide both email and password.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user = database.authenticate_user(email, password)
+        if user is None:
+            logger.warning("Failed web login attempt for %s", email)
+            return _render_login(
+                request,
+                email=email,
+                error="Invalid email or password. Please try again.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        existing_token = request.cookies.get(SESSION_COOKIE_NAME)
+        if existing_token:
+            session_manager.destroy(existing_token)
+
+        token = session_manager.create(user.id)
+        logger.info("User %s signed in to the web dashboard", user.id)
+        response = RedirectResponse(
+            request.url_for("ui_dashboard"), status_code=status.HTTP_303_SEE_OTHER
+        )
+        _issue_session_cookie(response, token)
+        return response
+
+    @router.get("/logout", name="ui_logout")
+    async def logout(request: Request):
+        token = request.cookies.get(SESSION_COOKIE_NAME)
+        response = RedirectResponse(
+            request.url_for("ui_login"), status_code=status.HTTP_303_SEE_OTHER
+        )
+        _clear_session_cookie(response, token)
+        return response
+
+    @router.get("/dashboard", response_class=HTMLResponse, name="ui_dashboard")
+    async def dashboard(request: Request):
+        user, token = _load_user(request)
+        if user is None:
+            response = RedirectResponse(
+                request.url_for("ui_login"), status_code=status.HTTP_303_SEE_OTHER
+            )
+            if token:
+                _clear_session_cookie(response, token)
+            return response
+
+        sessions = await registry.list_sessions(user_id=user.id)
+        summaries = [_session_to_summary(session, registry) for session in sessions]
+        online = sum(1 for summary in summaries if summary.is_online)
+
+        context = _base_context(
+            request,
+            user,
+            hypervisors=summaries,
+            hypervisor_count=len(summaries),
+            online_count=online,
+        )
+        response = _render_dashboard_response(request, context)
+        if token:
+            _issue_session_cookie(response, token)
+        return response
+
+    app.include_router(router)
+
+
+__all__ = ["register_ui_routes", "HypervisorSummary"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi>=0.110
 uvicorn>=0.22
 httpx>=0.24
+jinja2>=3.1
+python-multipart>=0.0.6

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,7 +179,7 @@ main() {
 [playrservers] Installation complete.
 The service files are located at: ${INSTALL_DIR}
 To activate the environment, run: source "${VENV_DIR}/bin/activate"
-Start the API with: "${VENV_DIR}/bin/python" "${INSTALL_DIR}/main.py" serve --host 0.0.0.0 --port 8000
+Start the API with: "${VENV_DIR}/bin/python" "${INSTALL_DIR}/main.py" serve --host 0.0.0.0 --port 443 --ssl-certfile /path/to/cert.pem --ssl-keyfile /path/to/key.pem
 EOM
 }
 

--- a/scripts/install_service.py
+++ b/scripts/install_service.py
@@ -73,7 +73,13 @@ def run_command(command: Sequence[str]) -> None:
     subprocess.check_call(command)
 
 
-REQUIRED_PACKAGES: tuple[str, ...] = ("fastapi", "uvicorn", "httpx")
+REQUIRED_PACKAGES: tuple[str, ...] = (
+    "fastapi",
+    "uvicorn",
+    "httpx",
+    "jinja2",
+    "python-multipart",
+)
 
 
 def install_dependencies(extra_args: Sequence[str]) -> None:
@@ -388,7 +394,10 @@ def main() -> int:
     print("\nInstallation complete!\n")
     print("Next steps:")
     service_entry = ROOT / "main.py"
-    start_command = f"python {service_entry} serve --host 0.0.0.0 --port 8000"
+    start_command = (
+        f"python {service_entry} serve --host 0.0.0.0 --port 443 "
+        "--ssl-certfile /path/to/cert.pem --ssl-keyfile /path/to/key.pem"
+    )
     print(f"  • Start the API with: {start_command}")
     print(f"  • Database stored at: {db_path}")
     return 0


### PR DESCRIPTION
## Summary
- add a session-backed web dashboard for administrators with login, logout, and paired hypervisor views
- ship templates, styling, and a Python session manager with graceful fallbacks when optional packages are missing
- expose HTTPS options in the CLI/installer docs and update dependencies for the UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf2b5916bc8331977df4ead8596a55