### PR TITLE
Add UI API key generation and prompt installer earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ provision QEMU, libvirt, and the PlayrServers agent runtime:
 curl -fsSL https://<host>/agent | sudo bash
 ```
 
-Create an API key for the agent using the bundled helper and supply it to the
-installer when prompted:
+Generate an API key for the agent from the web dashboard's **Agent installer**
+page or use the bundled helper and supply it to the installer when prompted:
 
 ```bash
 python scripts/create_api_key.py admin@example.com --name "DC-1 hypervisor"

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -117,6 +117,33 @@ body {
   line-height: 1.5;
 }
 
+.callout {
+  margin: 1.25rem 0;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: var(--surface-muted);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.callout code {
+  display: block;
+  white-space: pre-wrap;
+}
+
+.callout--success {
+  background: rgba(22, 163, 74, 0.12);
+  border-color: rgba(22, 163, 74, 0.35);
+  color: var(--success);
+}
+
+.callout--success code {
+  color: inherit;
+}
+
 .form {
   display: flex;
   flex-direction: column;

--- a/app/templates/agent_installer.html
+++ b/app/templates/agent_installer.html
@@ -11,6 +11,23 @@
   </div>
   <p>The installer configures QEMU, libvirt, and supporting packages before deploying the agent runtime and systemd service.</p>
   <p>{{ api_help }}</p>
+  <h2>Generate an API key</h2>
+  <p>Create a dedicated credential for hypervisors connecting back to this management plane.</p>
+  {% if api_key_error %}
+  <div class="alert alert--error">{{ api_key_error }}</div>
+  {% endif %}
+  {% if generated_api_key %}
+  <div class="callout callout--success">
+    <p><strong>Your new API key</strong></p>
+    <code>{{ generated_api_key }}</code>
+    <p class="text-muted">Copy this key now. It will not be shown again.</p>
+  </div>
+  {% endif %}
+  <form method="post" action="{{ request.url_for('ui_generate_api_key') }}" class="form">
+    <label class="form__label" for="api-key-name">Key name</label>
+    <input class="form__input" type="text" id="api-key-name" name="name" value="{{ api_key_form_name }}" required />
+    <button type="submit" class="button button--primary">Generate API key</button>
+  </form>
   <h2>Non-interactive usage</h2>
   <p>Pass installer flags to customise the deployment:</p>
   <pre><code>curl -fsSL {{ request.url_for('agent_installer_script') }} | sudo bash -s -- --api-key &lt;your-api-key&gt; --agent-id {{ user.name | replace(' ', '-') | lower }}</code></pre>

--- a/scripts/install_agent.sh
+++ b/scripts/install_agent.sh
@@ -565,8 +565,6 @@ main() {
   done
 
   require_root
-  install_packages
-  ensure_user
 
   if [[ -z "${agent_id}" ]]; then
     agent_id="$(hostname -s 2>/dev/null || hostname)"
@@ -584,6 +582,9 @@ main() {
     error "An API key is required to authenticate with the management plane"
     exit 1
   fi
+
+  install_packages
+  ensure_user
 
   ensure_directories "${agent_home}" "${config_file}" "${DEFAULT_LOG_DIR}"
   chown -R playr-agent:playr-agent "${agent_home}" "$(dirname "${config_file}")" "${DEFAULT_LOG_DIR}"


### PR DESCRIPTION
## Summary
- add API key generation workflow to the agent installer page, including fallback HTML support
- style callouts for API key feedback and document the web UI option for creating keys
- prompt for an API key before installing dependencies in the agent installer script

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf385c3c048331b4639479641b30b4