### PR TITLE
Add hypervisor dashboard header and ensure UI lists new agents

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -91,6 +91,92 @@ body {
   gap: 2rem;
 }
 
+.page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  padding: 1.5rem clamp(1rem, 4vw, 2.5rem);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(18px);
+}
+
+.page-head__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1 1 320px;
+}
+
+.page-head__title {
+  margin: 0;
+  font-size: 2.1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.page-head__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+  max-width: 48ch;
+}
+
+.page-head__metrics {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.page-head__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 120px;
+}
+
+.page-head__metric-value {
+  font-size: 1.9rem;
+  font-weight: 600;
+}
+
+.page-head__metric-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.page-head__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.page-head__actions .button {
+  box-shadow: 0 16px 36px rgba(37, 99, 235, 0.3);
+}
+
+@media (max-width: 640px) {
+  .page-head {
+    align-items: flex-start;
+  }
+
+  .page-head__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .page-head__actions .button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 .card {
   background: var(--surface);
   border-radius: 24px;

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -3,8 +3,28 @@
 {% block title %}Dashboard · PlayrServers Management{% endblock %}
 
 {% block content %}
+<header class="page-head">
+  <div class="page-head__content">
+    <h1 class="page-head__title">Hypervisors</h1>
+    <p class="page-head__subtitle">Monitor the systems paired with your management plane and review their tunnel activity.</p>
+    <div class="page-head__metrics">
+      <div class="page-head__metric">
+        <span class="page-head__metric-value">{{ hypervisor_count }}</span>
+        <span class="page-head__metric-label">Paired</span>
+      </div>
+      <div class="page-head__metric">
+        <span class="page-head__metric-value">{{ online_count }}</span>
+        <span class="page-head__metric-label">Online now</span>
+      </div>
+    </div>
+  </div>
+  <div class="page-head__actions">
+    <a class="button button--primary" href="{{ request.url_for('ui_agent_installer') }}">Add hypervisor</a>
+  </div>
+</header>
+
 <section class="card">
-  <h1 class="card__title">Account overview</h1>
+  <h2 class="card__title">Account overview</h2>
   <p class="card__subtitle">Review the details associated with your management account.</p>
   <dl class="detail-grid">
     <div class="detail-grid__item">
@@ -30,8 +50,8 @@
   </dl>
 </section>
 
-<section class="card">
-  <div class="card__title">Paired hypervisors</div>
+<section class="card" id="hypervisors">
+  <h2 class="card__title">Paired hypervisors</h2>
   <p class="card__subtitle">Hypervisors authenticate back to this control plane and surface secure tunnels.</p>
 
   {% if hypervisors %}


### PR DESCRIPTION
## Summary
- add a dedicated hypervisors header with metrics and call-to-action to the dashboard template and fallback renderer
- style the new page head component and surface newly connected agents first in the listing
- add a regression test that connects an agent through the API and verifies it appears on the dashboard

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf3ad2d4f8833182c6a0bd55ad06da