### PR TITLE
Default CLI to start API service automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ clean foundation.
   request encrypted tunnels that terminate on `manage.playrservers.com:443`.
 - ✅ **Secure web dashboard** – administrators can sign in at
   `https://<host>/` to review their account and view paired hypervisors.
-- ✅ **Command-line bootstrap** – `python main.py` initialises the database by
-  default, while `python main.py serve` launches the HTTP control plane.
+- ✅ **Command-line bootstrap** – `python main.py` now launches the management
+  service (initialising the database automatically). Access the interactive
+  console with `python main.py admin` when you need to manage accounts from the
+  terminal.
 
 ## Getting started
 
@@ -51,7 +53,8 @@ python scripts/install_service.py
 ```
 
 Use `--skip-deps` if you prefer to manage Python packages yourself. When the
-script completes you can start the API with `python main.py serve`.
+script completes you can start the management service with `python main.py`
+and optional flags (for example `--host`, `--port`, or TLS settings).
 
 To run the installer without interactive prompts, provide the initial account
 details via flags:
@@ -103,7 +106,7 @@ pip install -r requirements.txt
 Initialise the database and create a test user:
 
 ```bash
-python main.py
+python main.py init-db
 python scripts/create_user.py "Test User" test@example.com
 ```
 
@@ -114,7 +117,7 @@ your TLS certificate and private key so the management portal is available over
 HTTPS on port 443:
 
 ```bash
-python main.py serve \
+python main.py \
   --host 0.0.0.0 \
   --port 443 \
   --ssl-certfile /etc/ssl/certs/management.crt \

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="PlayrServers management utilities")
     subparsers = parser.add_subparsers(dest="command")
 
-    parser.set_defaults(command="admin")
+    parser.set_defaults(command="serve")
 
     subparsers.add_parser("init-db", help="Initialise the management database")
 
@@ -121,7 +121,21 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         ),
     )
 
-    return parser.parse_args(argv)
+    args_list = list(argv) if argv is not None else sys.argv[1:]
+    known_commands = {"serve", "admin", "init-db"}
+
+    if not args_list:
+        args_list = ["serve"]
+    else:
+        first = args_list[0]
+        if first in ("-h", "--help"):
+            return parser.parse_args(args_list)
+        if first not in known_commands:
+            if any(flag in args_list for flag in ("-h", "--help")):
+                return parser.parse_args(args_list)
+            args_list = ["serve", *args_list]
+
+    return parser.parse_args(args_list)
 
 
 def _project_root() -> Path:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,7 +179,7 @@ main() {
 [playrservers] Installation complete.
 The service files are located at: ${INSTALL_DIR}
 To activate the environment, run: source "${VENV_DIR}/bin/activate"
-Start the API with: "${VENV_DIR}/bin/python" "${INSTALL_DIR}/main.py" serve --host 0.0.0.0 --port 443 --ssl-certfile /path/to/cert.pem --ssl-keyfile /path/to/key.pem
+Start the management service with: "${VENV_DIR}/bin/python" "${INSTALL_DIR}/main.py" --host 0.0.0.0 --port 443 --ssl-certfile /path/to/cert.pem --ssl-keyfile /path/to/key.pem
 EOM
 }
 

--- a/scripts/install_service.py
+++ b/scripts/install_service.py
@@ -510,10 +510,10 @@ def main() -> int:
     print("Next steps:")
     service_entry = ROOT / "main.py"
     start_command = (
-        f"python {service_entry} serve --host 0.0.0.0 --port 443 "
+        f"python {service_entry} --host 0.0.0.0 --port 443 "
         "--ssl-certfile /path/to/cert.pem --ssl-keyfile /path/to/key.pem"
     )
-    print(f"  • Start the API with: {start_command}")
+    print(f"  • Start the management service with: {start_command}")
     print(f"  • Database stored at: {db_path}")
     print(f"  • systemd unit installed at: {service_unit_path}")
     return 0

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,18 @@
+from main import _parse_args
+
+
+def test_default_command_invokes_serve() -> None:
+    args = _parse_args([])
+    assert args.command == "serve"
+
+
+def test_default_command_accepts_options_without_subcommand() -> None:
+    args = _parse_args(["--host", "127.0.0.1", "--port", "8080"])
+    assert args.command == "serve"
+    assert args.host == "127.0.0.1"
+    assert args.port == 8080
+
+
+def test_admin_subcommand_still_available() -> None:
+    args = _parse_args(["admin"])
+    assert args.command == "admin"


### PR DESCRIPTION
## Summary
- default the CLI to the `serve` command and automatically prepend it when no subcommand is supplied so the API launches with the web service
- document the new behaviour in the README and installation scripts so operators can start the management service without a second command
- add unit tests covering the updated argument parsing logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf42b2b694833198f4837a757fb458