### PR TITLE
Expose root-level create_app factory to start API with web service

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from .database import Database, resolve_database_path
 
-__all__ = ["Database", "resolve_database_path"]
+
+def create_app(*args: Any, **kwargs: Any):
+    """Factory function that returns the combined web + API application."""
+
+    from .service import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
+
+__all__ = ["Database", "resolve_database_path", "create_app"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -281,6 +281,20 @@ class ManagementServiceTests(unittest.TestCase):
             self.assertEqual(redirected.status_code, 303)
             self.assertTrue(redirected.headers["location"].endswith("/login"))
 
+    def test_root_package_create_app_includes_api_and_web(self) -> None:
+        from app import create_app as root_create_app
+
+        registry = AgentRegistry()
+        app = root_create_app(database=self.database, registry=registry)
+
+        with TestClient(app, base_url="https://testserver") as client:
+            health = client.get("/healthz")
+            self.assertEqual(health.status_code, 200, health.text)
+
+            landing = client.get("/")
+            self.assertEqual(landing.status_code, 200, landing.text)
+            self.assertIn("Welcome back", landing.text)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- expose a lazy `create_app` factory from the `app` package so the combined web dashboard and agent API start together
- add a regression test to ensure the root factory provides both API and HTML routes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf45ee4e088331bf7cf02c30e05e5e