### PR TITLE
Ensure WebSocket dependencies are installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.110
-uvicorn>=0.22
+uvicorn[standard]>=0.22
 httpx>=0.24
 jinja2>=3.1
 python-multipart>=0.0.6
+websockets>=12.0

--- a/scripts/install_service.py
+++ b/scripts/install_service.py
@@ -115,6 +115,7 @@ REQUIRED_PACKAGES: tuple[PackageRequirement, ...] = (
     PackageRequirement("httpx", ("httpx",)),
     PackageRequirement("jinja2", ("jinja2",)),
     PackageRequirement("python-multipart", ("multipart",)),
+    PackageRequirement("websockets", ("websockets", "wsproto")),
 )
 
 SERVICE_NAME = "playr-management"


### PR DESCRIPTION
## Summary
- depend on `uvicorn[standard]` and add an explicit websockets requirement so the API server can accept WebSocket upgrades
- extend the installer dependency check to verify that a supported WebSocket implementation is present

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff48a14cc8331abf255c85b6bacdb