### PR TITLE
Fix SSH terminal to use configured tunnel host

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -1209,7 +1209,9 @@ def register_ui_routes(
 
         await websocket.accept()
 
-        ready = await _wait_for_port("127.0.0.1", tunnel.remote_port)
+        endpoint_host = registry.tunnel_host or "127.0.0.1"
+
+        ready = await _wait_for_port(endpoint_host, tunnel.remote_port)
         if not ready:
             with contextlib.suppress(Exception):
                 await websocket.send_text(
@@ -1220,6 +1222,10 @@ def register_ui_routes(
 
         login_user = tunnel.metadata.get("target_user") or "root"
         remote_port = tunnel.remote_port
+
+        ssh_target = endpoint_host
+        if ":" in ssh_target and not ssh_target.startswith("["):
+            ssh_target = f"[{ssh_target}]"
 
         command = [
             "ssh",
@@ -1236,7 +1242,7 @@ def register_ui_routes(
             "ConnectTimeout=10",
             "-p",
             str(remote_port),
-            f"{login_user}@127.0.0.1",
+            f"{login_user}@{ssh_target}",
         ]
 
         env = os.environ.copy()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -304,6 +304,9 @@ class ManagementServiceTests(unittest.TestCase):
             self.assertNotIn("ssh_command", terminal_payload)
             self.assertEqual(terminal_payload["remote_port"], 2200)
             self.assertEqual(terminal_payload["local_port"], 22)
+            self.assertIn("endpoint", terminal_payload)
+            self.assertEqual(terminal_payload["endpoint"].get("host"), registry.tunnel_host)
+            self.assertEqual(terminal_payload["endpoint"].get("port"), registry.tunnel_port)
             self.assertIn("websocket_path", terminal_payload)
             self.assertTrue(
                 terminal_payload["websocket_path"].startswith("/hypervisors/agent-detail/terminal/ws")


### PR DESCRIPTION
## Summary
- update the web SSH bridge to wait on and connect to the configured tunnel host instead of localhost, handling IPv6 addresses
- extend the terminal payload test to assert the exposed endpoint host and port

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01ba7000483319275363410e0cf96