### PR TITLE
Ensure web SSH terminal accepts keyboard input

### DIFF
--- a/app/templates/hypervisor.html
+++ b/app/templates/hypervisor.html
@@ -179,6 +179,8 @@
     let terminalInstance = null;
     let fitAddon = null;
     let resizeHandler = null;
+    let consoleClickHandler = null;
+    let consoleFocusHandler = null;
     const textDecoder = window.TextDecoder ? new TextDecoder() : null;
 
     const closeTerminal = () => {
@@ -207,6 +209,15 @@
       }
       terminalInstance = null;
       if (consoleElement) {
+        if (consoleClickHandler) {
+          consoleElement.removeEventListener('mousedown', consoleClickHandler);
+          consoleClickHandler = null;
+        }
+        if (consoleFocusHandler) {
+          consoleElement.removeEventListener('focus', consoleFocusHandler);
+          consoleFocusHandler = null;
+        }
+        consoleElement.removeAttribute('tabindex');
         consoleElement.innerHTML = '';
         consoleElement.setAttribute('hidden', 'hidden');
       }
@@ -258,6 +269,21 @@
 
       terminalInstance.open(consoleElement);
 
+      const focusTerminal = () => {
+        if (terminalInstance) {
+          terminalInstance.focus();
+        }
+      };
+
+      consoleElement.setAttribute('tabindex', '0');
+      consoleFocusHandler = focusTerminal;
+      consoleElement.addEventListener('focus', consoleFocusHandler);
+      consoleClickHandler = (event) => {
+        event.preventDefault();
+        focusTerminal();
+      };
+      consoleElement.addEventListener('mousedown', consoleClickHandler);
+
       if (fitAddon && typeof fitAddon.fit === 'function') {
         resizeHandler = () => {
           try {
@@ -270,7 +296,7 @@
         window.addEventListener('resize', resizeHandler);
       }
 
-      terminalInstance.focus();
+      focusTerminal();
 
       const wsTarget = buildWebSocketUrl(payload);
       if (!wsTarget) {


### PR DESCRIPTION
## Summary
- ensure the SSH terminal console restores its event handlers when opened or closed
- focus the embedded xterm instance when the console gains focus or is clicked so keystrokes are captured

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d032d3c6f8833187dae53fcdb0a18f