### PR TITLE
Fix SSH terminal connectivity host selection

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -312,6 +312,12 @@ class ManagementServiceTests(unittest.TestCase):
                 terminal_payload["websocket_path"].startswith("/hypervisors/agent-detail/terminal/ws")
             )
 
+            session = registry._sessions.get("agent-detail")
+            self.assertIsNotNone(session)
+            tunnels = list(session.tunnels.values())
+            self.assertEqual(len(tunnels), 1)
+            self.assertEqual(tunnels[0].metadata.get("target_user"), "admin")
+
             vm_action = client.post("/hypervisors/agent-detail/vms/web-01/start")
             self.assertEqual(vm_action.status_code, 202, vm_action.text)
             action_payload = vm_action.json()


### PR DESCRIPTION
## Summary
- use agent-provided SSH login metadata when creating terminal tunnels
- prefer loopback addresses when preparing the WebSocket SSH bridge so reverse tunnels come up reliably
- extend the management service test suite to assert the selected login metadata is stored on the tunnel

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d036319ba483319a2f5548ad039a8b