### PR TITLE
Prefer tunnel host when opening web terminal

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -1211,7 +1211,9 @@ def register_ui_routes(
         remote_port = tunnel.remote_port
 
         candidate_hosts: List[str] = []
-        for host in ("127.0.0.1", "::1", "localhost", registry.tunnel_host):
+        # Prefer the advertised tunnel host so we do not block on localhost probes
+        # when the reverse tunnel terminates on a remote bastion.
+        for host in (registry.tunnel_host, "127.0.0.1", "::1", "localhost"):
             if host and host not in candidate_hosts:
                 candidate_hosts.append(str(host))
 


### PR DESCRIPTION
## Summary
- prefer the registry tunnel host when probing for a ready SSH tunnel
- avoid long delays caused by unsuccessful localhost connection attempts before the remote bastion is tried

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d03cdeb8f483319160c0922826c496